### PR TITLE
Fix code example accuracy issues in part6, part7, and part11

### DIFF
--- a/part11-gateway-recovery.md
+++ b/part11-gateway-recovery.md
@@ -187,7 +187,7 @@ if ! curl -s http://localhost:8642/health > /dev/null 2>&1; then
 fi
 
 # Disk space OK?
-USAGE=$(df -h ~/.hermes | awk 'NR==2 {print $5}' | tr -d '%')
+USAGE=$(df -Ph ~/.hermes | awk 'NR==2 {print $5}' | tr -d '%')
 if [ "$USAGE" -gt 90 ]; then
     echo "WARNING: Disk usage at ${USAGE}%"
     exit 1

--- a/part6-context-compression.md
+++ b/part6-context-compression.md
@@ -47,7 +47,7 @@ try:
     compressed_context = summary
 except Exception as e:
     logger.warning(f"Context compression failed: {e}, preserving original context")
-    return original_context  # Don't compress, don't lose data
+    compressed_context = messages_to_compress  # Don't compress, don't lose data
 ```
 
 **The rule:** If compression can't succeed, keep the uncompressed context. A slower response is better than a wrong one.

--- a/part7-memory-system.md
+++ b/part7-memory-system.md
@@ -12,7 +12,7 @@
 | `session_search` | Search past conversation transcripts | "What did we decide about X?" or "Remember when we..." | Free (local) |
 | `skill_manage` | Procedural memory — reusable workflows | After fixing a bug, building something complex, or discovering a new approach | Free (local) |
 
-All three are **local-first**. No API calls, no embedding costs. They use SQLite and full-text search.
+All three are **local-first**. No embedding costs. They use SQLite and full-text search (query-based `session_search` may use an auxiliary LLM to summarize results — see Part 9).
 
 ## Tier 1: memory (Persistent Facts)
 


### PR DESCRIPTION
## Summary

Three small fixes to code examples across the guide to improve accuracy and reproducibility:

1. **part6-context-compression.md** — The "fixed" compression error-handler used `return original_context`, which introduces an undefined variable and switches from the assignment pattern used in the "broken" example (`compressed_context = ""`). Changed to `compressed_context = messages_to_compress` so both examples use consistent control flow and reference only variables visible in the snippet.

2. **part7-memory-system.md** — Removed the "No API calls" claim. `session_search` with a query can use an auxiliary LLM for summarization (documented in Part 9's auxiliary models table), so the blanket "no API calls" statement was inaccurate. Added a parenthetical cross-reference to Part 9.

3. **part11-gateway-recovery.md** — Health check script used `df -h` which can produce multi-line output per filesystem when device names are long, breaking the `awk 'NR==2'` extraction. Changed to `df -Ph` (POSIX format) to guarantee one line per filesystem.

## Review & Testing Checklist for Human

- [ ] **part6 fix — type semantics**: The broken example assigns a string (`""`) to `compressed_context`, and the fix now assigns `messages_to_compress` (likely a list of message objects, not a string). Verify this is the intended illustration — an alternative would be to keep the `return` early-exit pattern but use a defined variable, or to add a brief comment noting the type difference.
- [ ] **part7 wording**: Confirm the parenthetical about `session_search` using an auxiliary LLM is accurate per your understanding of Hermes internals. The claim is based on Part 9's auxiliary model config.

### Notes
- part10-soul-antipatterns.md was reviewed and contains no executable code examples (only markdown SOUL.md content blocks) — no changes needed.
- All changes are documentation-only; no functional code is affected.

Link to Devin session: https://app.devin.ai/sessions/2066c5f4b697452a853a925a9a19d7a3
Requested by: @OnlyTerp