### PR TITLE
docs: refresh Hermes guide for v0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Dated list of meaningful guide updates. Roughly [Keep a Changelog](https://keepachangelog.com) flavored.
 
+## 2026-05-25 — Hermes v0.14.0 Foundation Refresh
+
+### Added
+- v0.14 Foundation coverage: PyPI install path, lighter lazy-dependency installs, `hermes proxy`, `x_search`, `/handoff`, SuperGrok OAuth, Grok 4.3 1M context, and native Windows beta
+- Part 13 sections for the OpenAI-compatible local proxy and first-class X search
+- Part 15 coverage for Teams end-to-end, LINE, and SimpleX Chat, bringing gateway guidance to 22+ platforms
+- Part 18 May 25 coding-agent update notes for Claude Code Week 20+, Codex v0.133+, Gemini CLI v0.43, Zed ACP Registry, and proxy-backed Aider/Cline/Continue
+
+### Changed
+- README badges, “What's New,” quickstart/setup copy, platform counts, localized README summaries, roadmap, and outreach drafts now target Hermes v0.14.0 (v2026.5.16)
+- Part 9 model/provider guidance refreshed for May 25 SOTA: Grok 4.3, SuperGrok OAuth, OpenRouter/Nous live catalogs, Claude Sonnet 5 / Opus 4.7, GPT-5.5, Gemini 3.1, Kimi K2.6, GLM-5, DeepSeek V4, Qwen3.6, and current routing defaults
+- Config templates, wizard defaults, benchmark matrix, and reference architectures use current model identifiers and Cerebras Qwen 3 instead of older Llama/GPT-4.1/Gemini 2.5 framing
+- Part 23 reframed from v0.13-only Tenacity guidance to the current Foundation + Tenacity operating stack
+
+### Removed
+- v0.13-as-current framing from top-level guidance
+- Stale “Native Windows unsupported,” “20+ platforms,” Cerebras Llama 70B, GPT-4.1, and Gemini 2.5 recommendations where v0.14/May 25 defaults supersede them
+
 ## 2026-05-14 — Hermes v0.13.0 Tenacity Refresh
 
 ### Added

--- a/README-ja.md
+++ b/README-ja.md
@@ -2,7 +2,7 @@
 
 > [英語版はこちら](./README.md) · このページは入口の要約。本文の章は英語のまま。
 
-[NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)（v0.13.0 まで反映）向けの実戦ガイド + インストール可能な成果物（Skills・設定テンプレ・インフラスクリプト）。
+[NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)（v0.14.0 まで反映）向けの実戦ガイド + インストール可能な成果物（Skills・設定テンプレ・インフラスクリプト）。
 
 ## ワンコマンドで起動
 
@@ -15,7 +15,7 @@ curl -sSL https://raw.githubusercontent.com/OnlyTerp/hermes-optimization-guide/m
 
 ## 主なコンテンツ
 
-- **24 章の本文**（README 内の章 + `part6`〜`part23`） — Kanban、`/goal`、Checkpoints v2、Curator、TUI、プラグイン、LightRAG、Telegram、MCP、セキュリティ、可観測性、リモートサンドボックス
+- **24 章の本文**（README 内の章 + `part6`〜`part23`） — v0.14 Foundation、Grok OAuth、`hermes proxy`、LINE/SimpleX、Kanban、`/goal`、Checkpoints v2、Curator、TUI、プラグイン、LightRAG、Telegram、MCP、セキュリティ、可観測性、リモートサンドボックス
 - **13 個のインストール可能 Skill**（`skills/`） — 監査、バックアップ、依存スキャン、コストレポート、Telegram トリアージ、PR レビュー、受信トレイ整理、Hermes 週報、スパムフィルタ、会議準備 など
 - **5 つのプロダクション設定テンプレ**（`templates/config/`） — minimum / telegram-bot / production / cost-optimized / security-hardened
 - **インフラ一式**（`templates/compose/`, `templates/caddy/`, `templates/systemd/`, `scripts/`） — Langfuse セルフホスト、Caddy リバースプロキシ、systemd 強化、VPS ブートストラップ

--- a/README-zh.md
+++ b/README-zh.md
@@ -2,7 +2,7 @@
 
 > [English 完整版](./README.md) · 本页是入口摘要，章节正文仍为英文。
 
-实用指南 + 可安装制品（Skills、配置模板、基础设施脚本），针对 [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)（当前覆盖到 v0.13.0）。
+实用指南 + 可安装制品（Skills、配置模板、基础设施脚本），针对 [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)（当前覆盖到 v0.14.0）。
 
 ## 一键起步
 
@@ -15,7 +15,7 @@ curl -sSL https://raw.githubusercontent.com/OnlyTerp/hermes-optimization-guide/m
 
 ## 内容一览
 
-- **24 章正文**（README 内章节 + `part6` 到 `part23`） — Kanban、`/goal`、Checkpoints v2、Curator、TUI、插件、LightRAG、Telegram、MCP、安全、可观测性、远程沙箱
+- **24 章正文**（README 内章节 + `part6` 到 `part23`） — v0.14 Foundation、Grok OAuth、`hermes proxy`、LINE/SimpleX、Kanban、`/goal`、Checkpoints v2、Curator、TUI、插件、LightRAG、Telegram、MCP、安全、可观测性、远程沙箱
 - **13 个可安装 Skill**（`skills/`） — 审计、备份、依赖扫描、成本报告、Telegram 分类、PR 审查、收件箱分类、Hermes 周报、垃圾过滤、会议准备 等
 - **5 套生产配置模板**（`templates/config/`） — minimum / telegram-bot / production / cost-optimized / security-hardened
 - **基础设施**（`templates/compose/`, `templates/caddy/`, `templates/systemd/`, `scripts/`） — Langfuse 自托管、Caddy 反代、systemd 硬化、VPS 引导脚本

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # Hermes Optimization Guide
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
-[![Hermes](https://img.shields.io/badge/Hermes-v0.13.0%20%282026.5.7%29-9146FF)](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.7)
-[![Last updated](https://img.shields.io/badge/Last%20updated-2026--05--14-brightgreen)](./CHANGELOG.md)
+[![Hermes](https://img.shields.io/badge/Hermes-v0.14.0%20%282026.5.16%29-9146FF)](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.16)
+[![Last updated](https://img.shields.io/badge/Last%20updated-2026--05--25-brightgreen)](./CHANGELOG.md)
 [![Parts](https://img.shields.io/badge/parts-24-blue)](#table-of-contents)
 [![Skills](https://img.shields.io/badge/installable%20skills-13-blue)](./skills/)
 [![Configs](https://img.shields.io/badge/config%20templates-5-blue)](./templates/config/)
 [![CI](https://github.com/OnlyTerp/hermes-optimization-guide/actions/workflows/ci.yml/badge.svg)](./.github/workflows/ci.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 
-> **Current through Hermes Agent v0.13.0 (v2026.5.7)** · **24 parts, 13 installable guide skills, 5 opinionated configs, 4 reference architectures, one-command VPS bootstrap** · Updated for durable Kanban, `/goal`, Checkpoints v2, no-agent cron, Google Chat, provider plugins, v0.13 security defaults, Curator, the Ink TUI, plugins, Bedrock/Azure/LM Studio, remote model catalogs, dashboard chat, and the latest skill-hub workflows
+> **Current through Hermes Agent v0.14.0 (v2026.5.16)** · **24 parts, 13 installable guide skills, 5 opinionated configs, 4 reference architectures, one-command VPS bootstrap** · Updated for the Foundation release: PyPI installs, Grok OAuth + 1M context, `hermes proxy`, `x_search`, Teams end-to-end, LINE/SimpleX, `/handoff`, faster browser/CDP paths, native Windows beta, durable Kanban, `/goal`, Checkpoints v2, no-agent cron, Curator, plugins, and current May 2026 model routing
 >
 > Other languages: [中文](./README-zh.md) · [日本語](./README-ja.md)
 
 ### The End-to-End Hermes Guide — docs + runnable artifacts
-Every part you need to go from fresh install to a production Hermes deployment that talks on 20+ built-in/plugin platforms, orchestrates Claude Code / Codex / Gemini CLI through durable Kanban lanes, plugs into any MCP server, traces every call in Langfuse, curates its own skills, and runs heavy work on disposable Modal/Daytona/Vercel sandboxes — without burning $100/day on frontier tokens.
+Every part you need to go from fresh install to a production Hermes deployment that talks on 22+ built-in/plugin platforms, orchestrates Claude Code / Codex / Gemini CLI through durable Kanban lanes, plugs into any MCP server, traces every call in Langfuse, curates its own skills, and runs heavy work on disposable Modal/Daytona/Vercel sandboxes — without burning $100/day on frontier tokens.
 
 Unlike most guides, the prescriptions come with **working files**: [`skills/`](./skills) you can `ln -s` into `~/.hermes/skills/`, [`templates/config/`](./templates/config) you `cp` to `~/.hermes/config.yaml`, [`scripts/vps-bootstrap.sh`](./scripts/vps-bootstrap.sh) that takes a fresh VPS to production in one command.
 
-*By Terp — [Terp AI Labs](https://x.com/OnlyTerp)* · Last updated **May 14, 2026** · [CHANGELOG](./CHANGELOG.md) · [ROADMAP](./ROADMAP.md) · [ECOSYSTEM](./ECOSYSTEM.md)
+*By Terp — [Terp AI Labs](https://x.com/OnlyTerp)* · Last updated **May 25, 2026** · [CHANGELOG](./CHANGELOG.md) · [ROADMAP](./ROADMAP.md) · [ECOSYSTEM](./ECOSYSTEM.md)
 
 ---
 
@@ -63,7 +63,7 @@ Prefer a 5-minute local-only setup? → **[docs/quickstart.md](./docs/quickstart
 
 ```mermaid
 flowchart LR
-  Inputs[20+ platforms<br/>Telegram · Discord · Slack<br/>Google Chat · QQBot<br/>Yuanbao · Teams<br/>iMessage · WeChat · Email<br/>SMS · Webhooks · Cron · Voice · CLI] --> Gateway
+  Inputs[22+ platforms<br/>Telegram · Discord · Slack<br/>Google Chat · LINE · SimpleX<br/>Teams · QQBot · Yuanbao<br/>iMessage · WeChat · Email<br/>SMS · Webhooks · Cron · Voice · CLI] --> Gateway
   Gateway --> Router[Model Router<br/>cost + context + capability]
   Router --> Providers[Anthropic · OpenAI<br/>Google · Cerebras · Moonshot<br/>z.ai · xAI · Local]
   Gateway --> Approval[Approval Layer<br/>denylist · allowlist · quarantine]
@@ -87,16 +87,16 @@ This guide grew to 24 parts because *Hermes grew*. Six sections (Parts 1–5 plu
 [Part 1](#part-1-setup-stop-fumbling-with-installation) → [Part 4: Telegram](./part4-telegram-setup.md) → [Part 5: On-the-fly Skills](./part5-creating-skills.md) → [Part 7: Memory](./part7-memory-system.md).
 
 ### 🤖 "I want to drive Claude Code / Codex / Gemini from my phone"
-[Part 18: Coding Agents](./part18-coding-agents.md) → [Part 23: Tenacity Stack](./part23-tenacity-stack.md) → [Part 21: Remote Sandboxes](./part21-remote-sandboxes.md).
+[Part 18: Coding Agents](./part18-coding-agents.md) → [Part 23: Foundation + Tenacity Stack](./part23-tenacity-stack.md) → [Part 21: Remote Sandboxes](./part21-remote-sandboxes.md).
 
 ### 💼 "I'm running this in production"
-[Part 19: Security Playbook](./part19-security-playbook.md) → [Part 20: Observability & Cost](./part20-observability.md) → [Part 16: Backup & Debug](./part16-backup-debug.md) → [Part 23: Kanban + Goals](./part23-tenacity-stack.md).
+[Part 19: Security Playbook](./part19-security-playbook.md) → [Part 20: Observability & Cost](./part20-observability.md) → [Part 16: Backup & Debug](./part16-backup-debug.md) → [Part 23: Kanban + Goals + Handoff](./part23-tenacity-stack.md).
 
 ### 🧠 "I want the most capable agent possible, cost be damned"
 [Part 17: MCP Servers](./part17-mcp-servers.md) → [Part 18: Coding Agents](./part18-coding-agents.md) → [Part 3: LightRAG](./part3-lightrag-setup.md) → [Part 14: Fast Mode](./part14-fast-mode-watchers.md) → [Part 20: Observability](./part20-observability.md).
 
 ### 💰 "I want the cheapest possible agent that still works"
-[Part 9: Custom Models](./part9-custom-models.md) (Kimi/GLM/Gemini Flash routing) → [Part 20: Observability](./part20-observability.md#cost-routing-playbook-the-one-that-actually-saves-money) → [Part 6: Context Compression](./part6-context-compression.md).
+[Part 9: Custom Models](./part9-custom-models.md) (Grok/Gemini/Kimi/GLM routing) → [Part 20: Observability](./part20-observability.md#cost-routing-playbook-the-one-that-actually-saves-money) → [Part 6: Context Compression](./part6-context-compression.md).
 
 ### 🛡️ "I'm worried about prompt injection (you should be)"
 [Part 19: Security Playbook](./part19-security-playbook.md) — read this first if your agent reads any untrusted input (email, webhooks, Discord, public Telegram groups).
@@ -105,28 +105,31 @@ This guide grew to 24 parts because *Hermes grew*. Six sections (Parts 1–5 plu
 
 ## What's New (May 2026)
 
-Hermes moved again after the Curator/TUI refresh. The current stable target is **[v0.13.0 — 2026.5.7 — "The Tenacity Release"](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.7)**. This update folds the landed durability features into the guide and removes v0.12-as-current framing.
+Hermes moved again after the Tenacity refresh. The current stable target is **[v0.14.0 — 2026.5.16 — "The Foundation Release"](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.16)**. This update folds the landed install, proxy, platform, live-search, and performance features into the guide and removes v0.13-as-current framing.
+
+### v0.14.0 — "Foundation"
+
+- **PyPI + lighter installs** — `pip install hermes-agent` now works, heavy extras lazy-install on first use, `[all]` is debloated, and launch is roughly 19 seconds faster. See [Part 1](#part-1-setup-stop-fumbling-with-installation).
+- **Grok/SuperGrok OAuth + 1M context** — Grok 4.3 is now a native OAuth-backed provider with live X search, Custom Voices, and million-token research lanes. See [Part 9](./part9-custom-models.md).
+- **`hermes proxy`** — one OpenAI-compatible localhost endpoint for OAuth-backed Claude Pro, ChatGPT Pro, and SuperGrok so Codex, Aider, Cline, Continue, and scripts can reuse subscriptions. See [Part 13](./part13-tool-gateway.md#openai-compatible-local-proxy).
+- **`x_search`** — first-class X/Twitter search with OAuth or API-key auth for live threads and post lookup. See [Part 13](./part13-tool-gateway.md#x_search-first-class-x-search).
+- **Teams end-to-end + LINE + SimpleX Chat** — Microsoft Graph auth/listener/runtime/delivery is wired through, and the gateway reaches 22 messaging platforms. See [Part 15](./part15-new-platforms.md).
+- **Live `/handoff`** — transfer an active session to another model/profile/persona without losing messages or tool context. See [Part 23](./part23-tenacity-stack.md#8-upgrade-checklist-from-v013-to-v014).
+- **Performance wave** — persistent CDP makes browser-console work dramatically faster; `computer_use` gains a provider-agnostic CUA backend; Claude prompt prefixes cache for 1 hour across sessions. See [Part 20](./part20-observability.md).
+- **Editor + OS reach** — Zed ACP Registry integration via `uvx`, clickable terminal URLs, and native Windows beta widen how Hermes is driven. See [Part 18](./part18-coding-agents.md#agent-tooling-updates-may-25-2026).
 
 ### v0.13.0 — "Tenacity"
 
 - **Durable multi-agent Kanban** — boards, heartbeats, reclaim, retry budgets, zombie detection, and human unblock/review flow make long work auditable instead of fragile. See [Part 23](./part23-tenacity-stack.md#1-treat-kanban-as-the-durable-execution-layer).
 - **`/goal` persistent objectives** — keep a session locked on an observable target until done, paused, cleared, or out of budget. See [Part 23](./part23-tenacity-stack.md#3-use-goal-for-do-not-stop-until-it-is-done).
-- **Checkpoints v2** — real pruning, disk guardrails, cleaned-up shadow repos, and post-write syntax linting for Python/JSON/YAML/TOML. See [Part 23](./part23-tenacity-stack.md#4-checkpoints-v2-changes-your-risk-model).
-- **Gateway/session resilience** — gateway auto-resume after restarts, source reloads, and `/update` bounces; less lost state during unattended runs.
-- **Cron no-agent mode** — deterministic script-only watchdogs deliver stdout with zero LLM spend. See [Part 23](./part23-tenacity-stack.md#5-use-no_agent-cron-for-watchdogs).
-- **Google Chat + platform plugin hooks** — Google Chat is the 20th platform; IRC/Teams-style adapters can live outside core. See [Part 15](./part15-new-platforms.md#2026-update-google-chat-qqbot-yuanbao-and-teams).
-- **Providers are plugins** — provider profiles can ship out-of-tree, so new model backends no longer need core patches. See [Part 9](./part9-custom-models.md).
-- **Security defaults hardened** — secret redaction is on by default; Discord role allowlists are guild-scoped; WhatsApp rejects strangers by default; MCP OAuth/auth.json TOCTOU windows closed. See [Part 19](./part19-security-playbook.md#v013-security-defaults).
-- **Multimodal/media upgrades** — `video_analyze` for Gemini-compatible models, xAI Custom Voices, skill `[[as_document]]` routing, and image MCP result handling.
-- **Dashboard grows up** — Kanban, plugins page, profiles page, sortable analytics, reverse-proxy prefix support, and larger default theme.
-- **MCP transport reliability** — SSE OAuth forwarding, stale-pipe retries, keepalive for lifecycle waits, and image results surfaced as media.
+- **Checkpoints v2 + no-agent cron** — real pruning, gateway auto-resume, script-only watchdogs, and provider/platform plugin surfaces. See [Part 23](./part23-tenacity-stack.md).
 
 ### v0.12.0 — "Curator"
 
 - **Autonomous Curator** — `hermes curator` grades, consolidates, pins, archives, and restores agent-created skills on a default 7-day cadence. See [Part 22](./part22-latest-power-moves.md#1-turn-on-curator-before-your-skill-library-becomes-noise).
 - **Self-improvement loop upgraded** — the review fork is rubric-based, active-skill-biased, restricted to memory + skills tools, and correctly inherits the parent provider/model/credentials. See [Part 5](./part5-creating-skills.md#curator-v012-keep-the-skill-library-from-rotting).
 - **Provider expansion** — LM Studio became a first-class provider; GMI Cloud, Azure AI Foundry, MiniMax OAuth, Tencent TokenHub, AWS Bedrock, NVIDIA NIM, Vercel AI Gateway, Step Plan, Gemini OAuth, and Codex OAuth are now part of the realistic routing menu. See [Part 9](./part9-custom-models.md).
-- **Plugin-first gateway** — gateway platforms can ship as plugins; Microsoft Teams is the first plugin-shipped platform, and Tencent Yuanbao is the 18th native platform. See [Part 15](./part15-new-platforms.md#2026-update-qqbot-yuanbao-and-teams).
+- **Plugin-first gateway** — gateway platforms can ship as plugins; Microsoft Teams is the first plugin-shipped platform, and Tencent Yuanbao is the 18th native platform. See [Part 15](./part15-new-platforms.md#2026-update-teams-line-simplex-google-chat-qqbot-and-yuanbao).
 - **Bundled plugins worth enabling** — Spotify tools, Google Meet transcription/duplex audio, Langfuse observability, achievements, extra image providers, and dashboard skins. See [Part 22](./part22-latest-power-moves.md#4-use-plugins-for-integrations-not-one-off-scripts).
 - **Dashboard caught up** — Models tab, auxiliary-model configuration, dashboard Chat backed by the real `hermes --tui`, plugin slots, themes, update/restart controls, and better session analytics. See [Part 12](./part12-web-dashboard.md).
 - **TUI is now the primary interface** — `hermes --tui` adds sticky composer, slash autocomplete, live tool cards, `/steer`, `/queue`, `/background`, `/busy`, `/indicator`, voice parity, LaTeX, and better resume/delete flows. See [Part 22](./part22-latest-power-moves.md#2-use-the-tui-as-your-daily-driver).
@@ -147,7 +150,7 @@ Hermes moved again after the Curator/TUI refresh. The current stable target is *
 ### Still important from v0.9/v0.10
 
 - **Local web dashboard** (`hermes dashboard`) — config, API keys, sessions, logs, analytics, cron, skills, models, plugins, and optional browser Chat. See [Part 12](./part12-web-dashboard.md).
-- **Nous Tool Gateway** — Nous Portal subscribers can route web search, image generation, TTS, and browser automation through the subscription instead of juggling separate API keys. See [Part 13](./part13-tool-gateway.md).
+- **Tool Gateway + local proxy** — Nous Portal subscribers can route web/image/TTS/browser calls through one subscription, and v0.14 `hermes proxy` exposes OAuth-backed Claude/OpenAI/xAI through a loopback OpenAI-compatible endpoint. See [Part 13](./part13-tool-gateway.md).
 - **Fast Mode** (`/fast`) and **guided compression** (`/compress <topic>`) still matter, but they are no longer the whole story; pair them with auxiliary model routing and `/steer`. See [Part 14](./part14-fast-mode-watchers.md).
 - **MCP + coding-agent delegation + remote sandboxes** remain the high-leverage developer stack. See [Part 17](./part17-mcp-servers.md), [Part 18](./part18-coding-agents.md), and [Part 21](./part21-remote-sandboxes.md).
 
@@ -164,21 +167,21 @@ Hermes moved again after the Curator/TUI refresh. The current stable target is *
 7. [Context Compression](./part6-context-compression.md) — Fix the silent context loss bug, configure compression thresholds, survive long sessions
 8. [Memory System](./part7-memory-system.md) — The three-tier memory architecture: persistent facts, conversation recall, procedural memory
 9. [Subagent Patterns](./part8-subagent-patterns.md) — Orchestrator/worker delegation, ACP subagents, parallel task execution
-10. [Custom Model Providers](./part9-custom-models.md) — Bedrock, Azure AI Foundry, LM Studio, Gemini OAuth, Codex OAuth, OpenRouter routing, model aliases, fallback chains
+10. [Custom Model Providers](./part9-custom-models.md) — Grok/SuperGrok OAuth, Bedrock, Azure AI Foundry, LM Studio, Gemini OAuth, Codex OAuth, OpenRouter routing, model aliases, fallback chains
 11. [SOUL.md Anti-Patterns](./part10-soul-antipatterns.md) — What makes an agent annoying vs useful, the formula that works
 12. [Gateway Recovery](./part11-gateway-recovery.md) — Crash detection, auto-recovery, common failure modes, health checks
 13. [Web Dashboard](./part12-web-dashboard.md) — `hermes dashboard`, browser Chat via real TUI, models/plugins tabs, config, keys, sessions, logs, analytics, cron
-14. [Nous Tool Gateway](./part13-tool-gateway.md) — Web search, image gen, TTS, and browser automation through a single Nous Portal subscription
+14. [Tool Gateway, Local Proxy & Live Search](./part13-tool-gateway.md) — Nous-managed tools, `hermes proxy`, and `x_search`
 15. [Fast Mode & Background Watchers](./part14-fast-mode-watchers.md) — `/fast`, `/steer`, `/queue`, `watch_patterns`, pluggable context engine, `/compress <topic>`
-16. [New Platforms (iMessage, WeChat, Android)](./part15-new-platforms.md) — BlueBubbles/iMessage, Weixin/WeCom, QQBot, Yuanbao, Teams plugin, Android via Termux
+16. [New Platforms (Teams, LINE, SimpleX, iMessage, WeChat, Android)](./part15-new-platforms.md) — Teams end-to-end, LINE, SimpleX, Google Chat, QQBot, Yuanbao, BlueBubbles/iMessage, Weixin/WeCom, Android via Termux
 17. [Backup, Import & `/debug`](./part16-backup-debug.md) — Portable `hermes backup`/`import`, `/debug` bundler, `hermes debug share`, security hardening
 18. [MCP Servers](./part17-mcp-servers.md) — The tool-protocol standard. stdio + HTTP transports, sampling, trust boundaries, server shortlist, writing your own
-19. [Delegating to Coding Agents](./part18-coding-agents.md) — Claude Code, Codex, Gemini CLI, OpenCode, Aider. Print-mode, orchestrator subagents, ACP, git isolation, cost routing
+19. [Delegating to Coding Agents](./part18-coding-agents.md) — Claude Code Week 20+, Codex v0.133+, Gemini CLI v0.43, OpenCode, Aider, Zed ACP, print-mode, Kanban, git isolation
 20. [Security Playbook](./part19-security-playbook.md) — Prompt-injection defense, provenance labels, approval layers, secrets redaction, MCP trust model, hardline blocks
-21. [Observability & Cost Control](./part20-observability.md) — Langfuse plugin, Helicone, OpenTelemetry → Phoenix, auxiliary routing, eval-driven regressions
+21. [Observability & Cost Control](./part20-observability.md) — Langfuse plugin, Helicone, OpenTelemetry → Phoenix, prompt-prefix caching, CDP spans, auxiliary routing, evals
 22. [Remote Sandboxes & Bulk File Sync](./part21-remote-sandboxes.md) — SSH, Modal, Daytona, Vercel Sandbox, Fly Machines, E2B. Diff-based sync-back on teardown
 23. [Latest Power Moves](./part22-latest-power-moves.md) — Curator, TUI habits, context-file hygiene, plugins, dashboard Chat, cron chaining, and the 2026 upgrade checklist
-24. [Tenacity Stack](./part23-tenacity-stack.md) — Durable Kanban, `/goal`, Checkpoints v2, no-agent cron, worker lanes, and v0.13 upgrade checklist
+24. [Foundation + Tenacity Stack](./part23-tenacity-stack.md) — PyPI/lazy deps, `hermes proxy`, `/handoff`, durable Kanban, `/goal`, Checkpoints v2, no-agent cron, worker lanes, and v0.14 upgrade checklist
 
 ---
 
@@ -212,7 +215,7 @@ After this guide:
 - Python 3.11+ and Git
 - An API key for at least one LLM provider (Anthropic, OpenAI, OpenRouter, Nous Portal, etc.)
 - Optional: Ollama for local embeddings (free vector search)
-- Optional: A paid [Nous Portal](https://portal.nousresearch.com) subscription to use the [Tool Gateway](./part13-tool-gateway.md) — web search, image gen, TTS, and browser automation with no extra keys
+- Optional: a paid [Nous Portal](https://portal.nousresearch.com) subscription for managed tools, or OAuth-backed Claude/OpenAI/xAI subscriptions if you plan to use `hermes proxy`
 
 ---
 
@@ -263,12 +266,15 @@ For the full walkthrough including optimization, read each part in order.
 
 ## The Install
 
-One command. That's it.
+One command. That's it. v0.14 also ships on PyPI, so use the installer for the full local stack or `pip install hermes-agent` for the leanest CLI path.
 
 ### Linux / macOS / WSL2
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+
+# Lean v0.14+ path when you already manage Python yourself:
+pip install hermes-agent
 ```
 
 > **Security tip:** Piping scripts directly from the internet to bash executes them sight-unseen. If you prefer to inspect first:
@@ -278,7 +284,7 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 > bash install.sh
 > ```
 
-> **Windows users:** Native Windows is not supported. Install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run the command from inside WSL. It works perfectly.
+> **Windows users:** Native Windows is in beta in v0.14. For the most reliable path, use [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install); if you test native Windows, keep a backup and expect PTY/dashboard edge cases.
 
 > **Android users (new in v0.9):** the same installer detects Termux and installs the tested `[termux]` extra bundle automatically — CLI, cron, PTY/background terminal, Telegram gateway, MCP, Honcho, ACP. See [Part 15 — Android / Termux](./part15-new-platforms.md#android--termux-running-hermes-on-your-phone).
 
@@ -290,7 +296,7 @@ The installer handles everything automatically:
 - Installs **Python 3.11** via uv (no sudo needed)
 - Installs **Node.js v22** (for browser automation)
 - Installs **ripgrep** (fast file search) and **ffmpeg** (audio conversion)
-- Clones the Hermes repo
+- Installs the PyPI package or clones the Hermes repo when you choose source mode
 - Sets up the virtual environment
 - Creates the global `hermes` command
 - Runs the setup wizard for LLM provider configuration
@@ -324,10 +330,10 @@ Supported providers and recommended models:
 | **Anthropic** | Sonnet 5, Opus 4.7, Sonnet 4.6 | Best coding reliability, long unattended PR work, `/fast` priority tier | `ANTHROPIC_API_KEY` |
 | **OpenAI** | GPT-5.5, GPT-5 Codex, o-series | Strong tool use, sandboxed coding loops, deep reasoning, `/fast` priority tier | `OPENAI_API_KEY` |
 | **Xiaomi MiMo** | MiMo V2 Pro *(native adapter)* | Fast, cheap, native reasoning modes, great for orchestration | `XIAOMI_API_KEY` |
-| **xAI** | Grok 4.x, Grok Mini *(native adapter)* | Fast, good reasoning, native live-X search, Custom Voices | `XAI_API_KEY` |
+| **xAI** | Grok 4.3, Grok Mini *(native adapter + SuperGrok OAuth)* | 1M context, native live-X search, Custom Voices | `XAI_API_KEY` or OAuth |
 | **Kimi / Moonshot** | Kimi K2.6, Kimi 2.5 | Big context, excellent $/pass for code and extraction | `MOONSHOT_API_KEY` |
 | **z.ai / GLM** | GLM-5, GLM-5 Air | Strong open-weight tool use, great for translation + cheap reasoning | `ZAI_API_KEY` |
-| **Google** | Gemini 3.1 Pro, Gemini 2.5 Pro/Flash | Massive context, multimodal/video, cheap; OAuth supported via `hermes model` | `GEMINI_API_KEY` or OAuth |
+| **Google** | Gemini 3.1 Pro/Flash | Massive context, multimodal/video, cheap; OAuth supported via `hermes model` | `GEMINI_API_KEY` or OAuth |
 | **MiniMax** | M2.7+ | Good balance of speed, TTS, and quality | `MINIMAX_API_KEY` |
 | **Cerebras** | Llama 4 Scout, Qwen 3 32B | Blazing fast inference (2000+ tok/s), cheap | `CEREBRAS_API_KEY` |
 | **Groq** | Llama 4, Qwen 3 | Very fast inference, limited context | `GROQ_API_KEY` |
@@ -397,7 +403,7 @@ After initial setup, fine-tune with `hermes config set`:
 
 ```bash
 # Set primary model
-hermes config set model anthropic/claude-sonnet
+hermes config set model anthropic/claude-sonnet-5
 
 # Set fallback model (used when primary is rate-limited)
 hermes config set fallback_models '["openrouter/xiaomi/mimo-v2-pro"]'
@@ -824,7 +830,7 @@ This is the LLM that reads your documents and pulls out entities and relationshi
 |-------|-------|---------|------|----------------|
 | **Kimi 2.5** | Fast | Excellent | Cheap | **What we use.** Great balance of quality, speed, and cost for entity extraction |
 | **Cerebras + Qwen 3** | Blazing fast | Very good | Very cheap | **Fastest option in the world.** Cerebras inference at 2000+ tok/s makes bulk ingestion fly |
-| GPT-4.1-mini | Fast | Good | Cheap | Solid fallback, well-tested |
+| Gemini 3.1 Flash | Fast | Good | Cheap | Solid fallback, huge context |
 | Claude Sonnet 4 | Medium | Excellent | Mid-range | Overkill for ingestion but works great |
 | **Ollama local** | Depends on GPU | Unpredictable | Free | Untested for this use case — might mess up entity extraction quality. Use at your own risk |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,6 +24,7 @@ What's landing next. PRs welcome.
 
 ## Done (recent)
 
+- ✅ 2026-05-25 — v0.14 refresh: PyPI install, Grok OAuth, `hermes proxy`, `x_search`, Teams end-to-end, LINE/SimpleX, `/handoff`, Windows beta, and May 25 model SOTA
 - ✅ 2026-05-14 — v0.13 refresh: Kanban, `/goal`, Checkpoints v2, Google Chat, no-agent cron, provider plugins, and May 2026 model SOTA
 - ✅ 2026-04-30 — v0.11/v0.12 refresh: Curator, TUI, plugins, Bedrock/Azure/LM Studio, Teams/Yuanbao/QQBot, Vercel Sandbox, Part 22
 - ✅ 2026-04-17 — Interactive config wizard (`docs/wizard/`)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -51,8 +51,9 @@ Retail list prices; some providers may offer committed-use discounts.
 | google/gemini-3.1-flash | $0.08 | 11s | 19s | ✅ | Refresh against Gemini 3.1 Flash; was 4x cheaper, acceptable quality |
 | anthropic/claude-sonnet-5 | $0.72 | 19s | 31s | ✅ | Caps at 200K; refresh against Sonnet 5 |
 | openai/gpt-5.5 | $0.90 | 26s | 45s | ✅ | Refresh against GPT-5.5 |
+| xai/grok-4.3 | re-run | re-run | re-run | re-run | New v0.14 1M-context lane; do not quote until refreshed |
 
-**Recommendation:** Flash by default, Pro when you need the extra precision.
+**Recommendation:** Flash by default, Pro when you need precision, Grok 4.3 when live X context matters.
 
 ### T3: Code fix in 5K-line repo
 
@@ -91,7 +92,7 @@ Retail list prices; some providers may offer committed-use discounts.
 
 ## Delta from last snapshot
 
-- 2026-05-14: `benchmarks/matrix.yaml` updated with current frontier IDs (GPT-5.5, Claude Sonnet 5 / Opus 4.7, Gemini 3.1, Kimi K2.6, DeepSeek V4-Pro, Qwen3.6). Results above remain the dated 2026-04-17 run until `hermes evals run` is executed again.
+- 2026-05-25: `benchmarks/matrix.yaml` updated for the v0.14 refresh with Grok 4.3 1M context plus current frontier IDs (GPT-5.5, Claude Sonnet 5 / Opus 4.7, Gemini 3.1, Kimi K2.6, DeepSeek V4-Pro, Qwen3.6). Results above remain the dated 2026-04-17 run until `hermes evals run` is executed again.
 
 ---
 

--- a/benchmarks/matrix.yaml
+++ b/benchmarks/matrix.yaml
@@ -1,5 +1,5 @@
 # benchmarks/matrix.yaml — the provider x task matrix Hermes evals crank through.
-# Prices are a dated 2026-05-14 snapshot from provider docs/aggregators;
+# Prices are a dated 2026-05-25 snapshot from provider docs/aggregators;
 # `hermes evals run` should rehydrate live prices at runtime before publishing.
 
 models:
@@ -51,10 +51,10 @@ models:
     price_per_mtok_in: 0.60
     price_per_mtok_out: 0.60
     context_tokens: 128000
-  - id: xai/grok-4
+  - id: xai/grok-4.3
     price_per_mtok_in: 3.00
     price_per_mtok_out: 15.00
-    context_tokens: 256000
+    context_tokens: 1048576
 
 tasks:
   - id: T1_triage

--- a/docs/outreach/blog-post-long.md
+++ b/docs/outreach/blog-post-long.md
@@ -57,9 +57,9 @@ The default advice on cost is "use cheaper models". But you can't just set the c
 Here's what actually works, derived from our benchmarks:
 
 1. **Triage** (~60% of traffic for a personal bot): Gemini Flash. Cheap, fast, huge context. Routes to the right skill or punts to the right model.
-2. **Classification** (tagging, routing, spam-trap): Cerebras Llama 70B on a free tier. Effectively zero cost.
+2. **Classification** (tagging, routing, spam-trap): Cerebras Qwen 3 32B on a free tier. Effectively zero cost.
 3. **Default coding:** Kimi K2.6 / Moonshot. Cheap competent coder, good for routine changes.
-4. **Hard coding / architecture:** Anthropic Sonnet 5 or Opus 4.7. Opt-in (say "use sonnet" or mark the skill with `model: anthropic/claude-sonnet`).
+4. **Hard coding / architecture:** Anthropic Sonnet 5 or Opus 4.7. Opt-in (say "use sonnet" or mark the skill with `model: anthropic/claude-sonnet-5`).
 5. **Long-context research:** Gemini 3.1 Pro. 1M context + reasoning + media.
 
 With prompt caching on (Anthropic, OpenAI), `prefer_cached: true` as a default, and Fast Mode *off* unless you explicitly need it — the typical user month drops from $150 to $20–40.

--- a/docs/outreach/hacker-news-post.md
+++ b/docs/outreach/hacker-news-post.md
@@ -12,9 +12,9 @@
 
 Author here. Context on what this is and why:
 
-Hermes (Nous Research, ~94K GH stars) is the agent framework I've been using for a year. Most of the existing community guides explain the architecture but don't give you anything to run — you read 15 parts, still have to write your own `config.yaml`, your own cron skills, your own systemd hardening.
+Hermes (Nous Research, fast-growing GitHub project) is the agent framework I've been using for a year. Most of the existing community guides explain the architecture but don't give you anything to run — you read 15 parts, still have to write your own `config.yaml`, your own cron skills, your own systemd hardening.
 
-This guide is the other direction: 24 parts of actual documentation *plus*
+This guide is the other direction: 24 parts of actual documentation updated through Hermes v0.14 *plus*
 
 - **13 installable `SKILL.md` files** (audit-mcp, rotate-secrets, audit-approval-bypass, nightly-backup, weekly-dep-audit, cost-report, telegram-triage, pr-review, release-notes, daily-inbox-triage, hermes-weekly, spam-trap, meeting-prep) — drop them into `~/.hermes/skills/` or symlink them in
 - **5 opinionated configs** for the 5 real personas (minimum / telegram-bot / production / cost-optimized / security-hardened) — every non-obvious field commented
@@ -24,7 +24,7 @@ This guide is the other direction: 24 parts of actual documentation *plus*
 - **Reproducible cost benchmarks** — 12 flagship models × 5 canonical tasks (triage / summarize / codefix / deepreason / bulk-extract), methodology included, rerun-able with `hermes evals run`
 - **ECOSYSTEM.md** — 40+ curated MCP servers / coding agents / dashboard plugins
 
-The part I wanted to share specifically for HN: the **cost routing playbook** (Part 20) — five rules that drop typical agent spend ~90% (Gemini Flash for triage, Cerebras Llama for classification, Kimi/Moonshot as default coder, Sonnet only when you explicitly opt in, Gemini Pro for long-context). The benchmarks folder lets you verify yourself on your own workload.
+The part I wanted to share specifically for HN: the **cost routing playbook** (Part 20) — five rules that drop typical agent spend ~90% (Gemini Flash for triage, Cerebras Qwen 3 for classification, Kimi/Moonshot as default coder, Sonnet only when you explicitly opt in, Gemini Pro for long-context). The benchmarks folder lets you verify yourself on your own workload.
 
 And the **defensive security playbook** (Part 19) — written after the Apr 15 "Comment and Control" cross-vendor prompt-injection disclosure that hit Claude Code + Gemini CLI + Copilot Agent. Seven layers: provenance labels, approval, secret isolation, webhook signatures, SSRF, MCP trust levels, quarantine profiles. If your coding agent reads arbitrary PR bodies or emails, this is the hardening posture I wish I'd had 6 months ago.
 

--- a/docs/outreach/launch-tweet-thread.md
+++ b/docs/outreach/launch-tweet-thread.md
@@ -59,10 +59,10 @@ Part 19 is the defensive playbook: 7 layers (provenance, approval, secret isolat
 **7/8**
 Cost routing playbook (Part 20) drops a typical workload by ~90%:
 - Triage → Gemini Flash or Cerebras
-- Classification → Cerebras Llama (~free)
+- Classification → Cerebras Qwen 3 (~free)
 - Default coding → Kimi/Moonshot
 - Hard coding → Sonnet (explicit opt-in)
-- Long context → Gemini 2.5 Pro
+- Long context → Gemini 3.1 Pro
 
 Benchmarks + methodology in `benchmarks/`.
 

--- a/docs/outreach/reddit-localllama.md
+++ b/docs/outreach/reddit-localllama.md
@@ -18,7 +18,7 @@ I built a Hermes (Nous Research's agent framework) optimization guide that goes 
 
 - **Homelab reference architecture** — full setup for running Hermes + LightRAG + self-hosted Langfuse on your own box, with Ollama as the default provider and routing only the hard stuff to Sonnet. Tailscale instead of port-forwarding. Scaling ceilings + honest tradeoffs (latency, quality, etc.) included.
 
-- **5 production config templates** — one of them is `cost-optimized.yaml`, which uses Gemini Flash + Cerebras Llama for most traffic and only escalates to Sonnet on explicit opt-in. Typical spend is $0.05–0.30/active-hour.
+- **5 production config templates** — one of them is `cost-optimized.yaml`, which uses Gemini Flash + Cerebras Qwen 3 for most traffic and only escalates to Sonnet on explicit opt-in. Typical spend is $0.05–0.30/active-hour.
 
 - **Reproducible benchmarks** — 12 flagship models × 5 tasks (triage / summarize / codefix / deepreason / bulk-extract), methodology + `hermes evals run` command to reproduce.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -77,7 +77,7 @@ Now try:
 
 ## Step 7 — Level up
 
-- **More platforms:** [Part 4 (Telegram deep-dive)](../part4-telegram-setup.md), [Part 15 (iMessage/WeChat/Android)](../part15-new-platforms.md)
+- **More platforms:** [Part 4 (Telegram deep-dive)](../part4-telegram-setup.md), [Part 15 (Teams/LINE/SimpleX/iMessage/WeChat/Android)](../part15-new-platforms.md)
 - **Latest features:** [Part 22 (Curator, TUI, plugins)](../part22-latest-power-moves.md), [Part 23 (Kanban, `/goal`, Checkpoints v2)](../part23-tenacity-stack.md)
 - **Memory that reasons:** [Part 3 (LightRAG)](../part3-lightrag-setup.md)
 - **Tools:** [Part 17 (MCP servers)](../part17-mcp-servers.md)

--- a/docs/reference-architectures/homelab.md
+++ b/docs/reference-architectures/homelab.md
@@ -83,9 +83,9 @@ models:
 
   routing:
     - when: task == "reasoning"
-      use: anthropic/claude-sonnet
+      use: anthropic/claude-sonnet-5
     - when: task == "coding" && complexity == "high"
-      use: anthropic/claude-sonnet
+      use: anthropic/claude-sonnet-5
 
 gateways:
   cli:

--- a/docs/reference-architectures/small-agency.md
+++ b/docs/reference-architectures/small-agency.md
@@ -89,10 +89,10 @@ systemctl enable --now hermes@alice.service
 
 Use [`templates/config/production.yaml`](../../templates/config/production.yaml) as the base. Key rules:
 
-- **Triage** (most traffic): Cerebras Llama 70B — free-ish tier
+- **Triage** (most traffic): Cerebras Qwen 3 32B — free-ish tier
 - **Default coding:** Kimi/Moonshot (cheap competent coder)
 - **"Hard" coding / architecture:** Anthropic Sonnet — explicit opt-in
-- **Long-context research:** Gemini 2.5 Pro
+- **Long-context research:** Gemini 3.1 Pro
 - **Deep reasoning:** OpenAI reasoning model (opt-in)
 
 With weekly `cost-report` → Discord ops channel, cost anomalies surface before the invoice.

--- a/docs/reference-architectures/solo-developer.md
+++ b/docs/reference-architectures/solo-developer.md
@@ -60,7 +60,7 @@ sudo systemctl start hermes hermes-dashboard
 
 ## Why `cost-optimized.yaml` is the right default
 
-See [`templates/config/cost-optimized.yaml`](../../templates/config/cost-optimized.yaml). Defaults to Gemini Flash (cheapest smart model), uses Cerebras Llama for classification (near-free), and only escalates to Sonnet for high-stakes coding. With prompt caching + Fast Mode disabled by default, typical cost is $0.05–0.30 per active hour.
+See [`templates/config/cost-optimized.yaml`](../../templates/config/cost-optimized.yaml). Defaults to Gemini Flash (cheapest smart model), uses Cerebras Qwen 3 for classification (near-free), and only escalates to Sonnet for high-stakes coding. With prompt caching + Fast Mode disabled by default, typical cost is $0.05–0.30 per active hour.
 
 If you need max quality for a specific task, just say "use sonnet" in chat — the router honors explicit user overrides.
 

--- a/docs/wizard/index.html
+++ b/docs/wizard/index.html
@@ -75,11 +75,12 @@
       <legend>2. Default model</legend>
       <p class="hint">Can be overridden per-skill.</p>
       <select name="default_model">
-        <option value="anthropic/claude-sonnet">Anthropic Claude Sonnet 5 (balanced default)</option>
-        <option value="anthropic/claude-opus">Anthropic Claude Opus 4.7 (max capability)</option>
+        <option value="anthropic/claude-sonnet-5">Anthropic Claude Sonnet 5 (balanced default)</option>
+        <option value="anthropic/claude-opus-4.7">Anthropic Claude Opus 4.7 (max capability)</option>
         <option value="google/gemini-3.1-flash">Google Gemini 3.1 Flash (cheap + fast + huge context)</option>
         <option value="google/gemini-3.1-pro">Google Gemini 3.1 Pro (1M context + reasoning/media)</option>
         <option value="openai/gpt-5.5">OpenAI GPT-5.5 (deep reasoning)</option>
+        <option value="xai/grok-4.3">xAI Grok 4.3 (1M context + live X search)</option>
         <option value="moonshot/kimi-k2.6">Moonshot Kimi K2.6 (cheap + strong coding)</option>
         <option value="zai/glm">z.ai GLM (very cheap)</option>
       </select>
@@ -187,7 +188,7 @@ function select(name) {
    rest of the form is pre-filled so Question 1 actually drives output. */
 const PERSONA_PRESETS = {
   'minimum': {
-    default_model: 'anthropic/claude-sonnet',
+    default_model: 'anthropic/claude-sonnet-5',
     memory: 'vector',
     gateways: { cli: true, telegram: false, discord: false, slack: false, email: false, webhook: false },
     mcps:     { github: false, postgres: false, cloudflare: false, linear: false, filesystem: false, mem0: false },
@@ -196,7 +197,7 @@ const PERSONA_PRESETS = {
     crons:    { backup: false, deps: false, cost: false, mcp: false },
   },
   'telegram-bot': {
-    default_model: 'anthropic/claude-sonnet',
+    default_model: 'anthropic/claude-sonnet-5',
     memory: 'lightrag',
     gateways: { cli: true, telegram: true, discord: false, slack: false, email: false, webhook: false },
     mcps:     { github: true, postgres: false, cloudflare: false, linear: false, filesystem: false, mem0: false },
@@ -205,7 +206,7 @@ const PERSONA_PRESETS = {
     crons:    { backup: true, deps: false, cost: true, mcp: false },
   },
   'production': {
-    default_model: 'anthropic/claude-sonnet',
+    default_model: 'anthropic/claude-sonnet-5',
     memory: 'lightrag',
     gateways: { cli: true, telegram: true, discord: true, slack: true, email: true, webhook: true },
     mcps:     { github: true, postgres: true, cloudflare: true, linear: true, filesystem: true, mem0: false },
@@ -223,7 +224,7 @@ const PERSONA_PRESETS = {
     crons:    { backup: true, deps: false, cost: true, mcp: false },
   },
   'security-hardened': {
-    default_model: 'anthropic/claude-sonnet',
+    default_model: 'anthropic/claude-sonnet-5',
     memory: 'vector',
     gateways: { cli: true, telegram: true, discord: false, slack: false, email: false, webhook: true },
     mcps:     { github: true, postgres: false, cloudflare: false, linear: false, filesystem: false, mem0: false },
@@ -308,12 +309,13 @@ function generate() {
     moonshot:  'MOONSHOT_API_KEY',
     zai:       'ZAI_API_KEY',
     cerebras:  'CEREBRAS_API_KEY',
+    xai:       'XAI_API_KEY',
   };
   // Providers required by each persona's routing rules (must be superset of
   // models referenced in routing blocks later in this function).
   const EXTRA_PROVIDERS = {
     'cost-optimized': ['anthropic', 'google', 'moonshot', 'cerebras'],
-    'production':     ['anthropic', 'google'],
+    'production':     ['anthropic', 'google', 'xai'],
     'security-hardened': ['anthropic'],
   };
   const providersToEmit = new Set([model.split('/')[0]]);
@@ -508,7 +510,7 @@ function generate() {
     lines.push(`    - { when: "task.type == 'classify'",       use: "cerebras/qwen-3-32b" }`);
     lines.push(`    - { when: "context.tokens > 200000",        use: "google/gemini-3.1-pro" }`);
     lines.push(`    - { when: "task.type == 'code'",            use: "moonshot/kimi-k2.6" }`);
-    lines.push(`    - { when: "task.explicit_opt_in == 'sonnet'", use: "anthropic/claude-sonnet" }`);
+    lines.push(`    - { when: "task.explicit_opt_in == 'sonnet'", use: "anthropic/claude-sonnet-5" }`);
     lines.push(`    - { else: true,                              use: "google/gemini-3.1-flash" }`);
     lines.push(``);
   }

--- a/part1-setup.md
+++ b/part1-setup.md
@@ -6,12 +6,15 @@
 
 ## The Install
 
-One command. That's it.
+One command. That's it. v0.14 also ships on PyPI, so use the installer for the full local stack or `pip install hermes-agent` for the leanest CLI path.
 
 ### Linux / macOS / WSL2
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+
+# Lean v0.14+ path when you already manage Python yourself:
+pip install hermes-agent
 ```
 
 > **Security tip:** Piping scripts directly from the internet to bash executes them sight-unseen. If you prefer to inspect first:
@@ -21,7 +24,7 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 > bash install.sh
 > ```
 
-> **Windows users:** Native Windows is not supported. Install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run the command from inside WSL. It works perfectly.
+> **Windows users:** Native Windows is in beta in v0.14. Use [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) for production/stable gateway work; try native Windows only after backing up config and expecting PTY/dashboard quirks.
 
 ### What the Installer Does
 
@@ -31,7 +34,7 @@ The installer handles everything automatically:
 - Installs **Python 3.11** via uv (no sudo needed)
 - Installs **Node.js v22** (for browser automation)
 - Installs **ripgrep** (fast file search) and **ffmpeg** (audio conversion)
-- Clones the Hermes repo
+- Installs the PyPI package or clones the Hermes repo when you choose source mode
 - Sets up the virtual environment
 - Creates the global `hermes` command
 - Runs the setup wizard for LLM provider configuration
@@ -62,11 +65,11 @@ Supported providers:
 | Provider | Best For | Env Variable |
 |----------|----------|-------------|
 | Anthropic (Claude) | Highest quality, best at complex tasks | `ANTHROPIC_API_KEY` |
-| OpenAI (GPT-4.1/o3) | Strong tool use, fast | `OPENAI_API_KEY` |
+| OpenAI (GPT-5.5/Codex) | Strong tool use, sandboxed coding, deep reasoning | `OPENAI_API_KEY` |
 | OpenRouter | Access 100+ models from one key | `OPENROUTER_API_KEY` |
 | Cerebras | Fast inference, good for simple tasks | `CEREBRAS_API_KEY` |
 | Groq | Very fast, limited context | `GROQ_API_KEY` |
-| xAI (Grok) | Good balance of speed/quality | `XAI_API_KEY` |
+| xAI (Grok / SuperGrok OAuth) | Live X search, Grok 4.3 1M context, Custom Voices | `XAI_API_KEY` or OAuth |
 | Google (Gemini) | Huge context, cheap | `GEMINI_API_KEY` |
 
 You can configure **multiple providers** with automatic fallback. If one goes down, Hermes switches to the next.
@@ -115,7 +118,7 @@ After initial setup, fine-tune with `hermes config set`:
 
 ```bash
 # Set primary model
-hermes config set model anthropic/claude-sonnet
+hermes config set model anthropic/claude-sonnet-5
 
 # Set fallback model (used when primary is rate-limited)
 hermes config set fallback_models '["openrouter/anthropic/claude-sonnet-5"]'

--- a/part11-gateway-recovery.md
+++ b/part11-gateway-recovery.md
@@ -71,7 +71,7 @@ systemctl edit hermes-gateway
 ```yaml
 model_fallback:
   - provider: cerebras
-    model: llama-3.3-70b
+    model: qwen-3-32b
   - provider: openrouter
     model: anthropic/claude-sonnet-5
   - provider: local

--- a/part12-web-dashboard.md
+++ b/part12-web-dashboard.md
@@ -1,6 +1,6 @@
 # Part 12: The Local Web Dashboard (Stop Editing YAML)
 
-*Introduced in v0.9 and substantially upgraded through v0.13. The dashboard is now a browser-based control panel for config, Chat/TUI, Kanban, plugins, profiles, and analytics — not just a YAML editor.*
+*Introduced in v0.9 and substantially upgraded through v0.14. The dashboard is now a browser-based control panel for config, Chat/TUI, Kanban, plugins, profiles, and analytics — not just a YAML editor.*
 
 ---
 
@@ -90,7 +90,7 @@ Requirements:
 
 - Node.js for the Ink TUI bundle
 - `ptyprocess` via `pip install 'hermes-agent[pty]'`
-- POSIX PTY support: Linux, macOS, or WSL; native Windows Python is not supported for the embedded PTY
+- POSIX PTY support: Linux, macOS, or WSL for the embedded PTY; native Windows is beta in v0.14 and may still need WSL for dashboard Chat
 
 Tip: launch from the Sessions page with the play icon to resume a past session directly into `/chat?resume=<id>`.
 
@@ -364,4 +364,4 @@ Config is read at session start and gateway start. For an active CLI session, ru
 
 - **Save on API keys:** [Part 13 — Nous Tool Gateway](./part13-tool-gateway.md)
 - **Speed up responses:** [Part 14 — Fast Mode & Background Watchers](./part14-fast-mode-watchers.md)
-- **Expand reach:** [Part 15 — New Platforms (iMessage, WeChat, Android)](./part15-new-platforms.md)
+- **Expand reach:** [Part 15 — New Platforms (Teams, LINE, SimpleX, iMessage, WeChat, Android)](./part15-new-platforms.md)

--- a/part13-tool-gateway.md
+++ b/part13-tool-gateway.md
@@ -1,6 +1,6 @@
-# Part 13: The Nous Tool Gateway (One Subscription, Four Tools, Zero Extra Keys)
+# Part 13: Tool Gateway, Local Proxy, and Live Search
 
-*If you have a paid Nous Portal subscription, you already have web search, image generation, text-to-speech, and browser automation — you just haven't turned them on yet.*
+*If you have a paid Nous Portal or OAuth-backed provider subscription, Hermes can turn it into tools: managed web/image/TTS/browser calls, an OpenAI-compatible local proxy, and first-class live X search.*
 
 ---
 
@@ -154,6 +154,35 @@ web:
 ```
 
 When you pick a non-gateway provider in `hermes tools`, `use_gateway` is automatically set to `false` to prevent contradictory config.
+
+---
+
+## OpenAI-Compatible Local Proxy
+
+v0.14 adds `hermes proxy`: a local OpenAI-compatible endpoint backed by whichever OAuth provider you are signed into — Claude Pro, ChatGPT Pro/Codex, or SuperGrok. This is the clean way to let Codex CLI, Aider, Cline, Continue, or internal scripts reuse subscriptions without copying API keys.
+
+```bash
+hermes model          # sign in to Claude / OpenAI / xAI OAuth first
+hermes proxy --host 127.0.0.1 --port 11435
+```
+
+Then point OpenAI-compatible clients at `http://127.0.0.1:11435/v1` with a local dummy key. Keep it loopback-only unless you add real auth in front.
+
+---
+
+## `x_search`: First-Class X Search
+
+Use `x_search` when the source of truth is a live X/Twitter thread, launch post, or maintainer account. It supports X OAuth or API-key auth, and pairs naturally with Grok 4.3 / SuperGrok OAuth.
+
+```yaml
+tools:
+  x_search:
+    enabled: true
+    auth: oauth        # or api_key
+    max_results: 25
+```
+
+Use broader web search for docs/blogs; use `x_search` for real-time social signal.
 
 ---
 

--- a/part14-fast-mode-watchers.md
+++ b/part14-fast-mode-watchers.md
@@ -282,7 +282,7 @@ Without a topic, it runs with its default heuristics. With one, the summarizer p
 
 ## `/goal` — Persistent Target Locking
 
-v0.13 adds `/goal` for the long-loop version of this problem: not "compress this context," but "keep working until this observable objective is done."
+v0.13 added `/goal`, and v0.14 pairs it with live `/handoff` for model/profile transfers for the long-loop version of this problem: not "compress this context," but "keep working until this observable objective is done."
 
 ```text
 /goal Migrate the gateway to Google Chat, run checks, and leave a PR link.
@@ -295,5 +295,5 @@ Use it when the agent should continue across tool calls and intermediate updates
 ## What's Next
 
 - **Save keys + streamline setup:** [Part 13 — Nous Tool Gateway](./part13-tool-gateway.md)
-- **Expand reach:** [Part 15 — New Platforms (iMessage, WeChat, Android)](./part15-new-platforms.md)
+- **Expand reach:** [Part 15 — New Platforms (Teams, LINE, SimpleX, iMessage, WeChat, Android)](./part15-new-platforms.md)
 - **Disaster recovery:** [Part 16 — Backup, Debug, and Pluggable Context](./part16-backup-debug.md)

--- a/part15-new-platforms.md
+++ b/part15-new-platforms.md
@@ -1,12 +1,12 @@
-# Part 15: Messaging Platforms (Google Chat, iMessage, WeChat, QQBot, Yuanbao, Teams, Android)
+# Part 15: Messaging Platforms (Teams, LINE, SimpleX, Google Chat, iMessage, WeChat, Android)
 
-*Hermes' gateway is now a plugin host. v0.9 made Hermes "everywhere"; v0.11/v0.12 added QQBot, Tencent Yuanbao, and Microsoft Teams; v0.13 adds Google Chat and reinforces platform adapters as opt-in plugins.*
+*Hermes' gateway is now a plugin host. v0.9 made Hermes "everywhere"; v0.11/v0.12 added QQBot, Tencent Yuanbao, and Microsoft Teams; v0.13 added Google Chat; v0.14 wires Teams end-to-end and adds LINE + SimpleX Chat.*
 
 ---
 
-## The 20+ Platform Lineup
+## The 22+ Platform Lineup
 
-As of v0.13, the gateway ships built-in adapters plus plugin-shipped platforms:
+As of v0.14, the gateway ships built-in adapters plus plugin-shipped platforms:
 
 | Platform | Mode | Notes |
 |----------|------|-------|
@@ -14,13 +14,15 @@ As of v0.13, the gateway ships built-in adapters plus plugin-shipped platforms:
 | Discord | WebSocket (bot) | Slash commands, voice/media, DMs + servers |
 | Slack | Socket / Events API | Threads, file uploads, blocks |
 | **Google Chat** | App / webhook | **New in v0.13**, Workspace-native chat surface |
+| **LINE** | Messaging API | **New in v0.14**, Japan/Korea/Taiwan mobile-first surface |
+| **SimpleX Chat** | Decentralized chat | **New in v0.14**, privacy-first chat with no user IDs |
 | WhatsApp | Web API | QR-code login, requires always-on node |
 | **iMessage (BlueBubbles)** | Webhook | **New in v0.9** |
 | **Weixin (WeChat personal)** | Long-poll | **New in v0.9** |
 | **WeCom (Enterprise WeChat)** | Webhook | **New in v0.9** |
 | **QQBot** | WebSocket/Webhook | Added after the original v0.9 platform sweep |
 | **Tencent Yuanbao** | Native gateway | **New in v0.12**, text + media delivery |
-| **Microsoft Teams** | Plugin | **New in v0.12**, first plugin-shipped gateway platform |
+| **Microsoft Teams** | Graph + webhook + runtime + delivery | End-to-end in v0.14 |
 | Signal | REST via signal-cli | Self-hosted bridge |
 | DingTalk | Webhook | Corporate IM, China/APAC |
 | Feishu / Lark | Webhook | Corporate IM, ByteDance |
@@ -39,13 +41,58 @@ All of them respect:
 - The shared session database (Part 7)
 - Pre-dispatch plugin hooks
 
-This part covers the v0.9 adapters, the newer v0.12/v0.13 surfaces, and **Android / Termux** — running the agent itself on a phone.
+This part covers the v0.9 adapters, the newer v0.12–v0.14 surfaces, and **Android / Termux** — running the agent itself on a phone.
 
-## 2026 Update: Google Chat, QQBot, Yuanbao, and Teams
+## 2026 Update: Teams, LINE, SimpleX, Google Chat, QQBot, and Yuanbao
+
+### Microsoft Teams
+
+Teams is no longer just a proof of the v0.12 plugin architecture. In v0.14 the Graph auth, webhook listener, pipeline runtime, and outbound delivery are wired together, so Teams can be a real enterprise chat surface.
+
+```yaml
+gateways:
+  teams:
+    enabled: true
+    tenant_id: ${MICROSOFT_TENANT_ID}
+    client_id: ${MICROSOFT_TEAMS_CLIENT_ID}
+    client_secret: ${MICROSOFT_TEAMS_CLIENT_SECRET}
+    allowed_teams:
+      - ${MICROSOFT_TEAMS_ADMIN_TEAM}
+    trust_label: medium
+```
+
+Keep approvals in a private admin channel, not in the same team/channel where untrusted requests arrive.
+
+### LINE
+
+Use LINE when your users are in Japan, Korea, Taiwan, or a consumer/mobile-first workflow. Treat it like Telegram operationally: one admin bot/channel for approvals, strict allowed user IDs, and no write tools in public rooms.
+
+```yaml
+gateways:
+  line:
+    enabled: true
+    channel_access_token: ${LINE_CHANNEL_ACCESS_TOKEN}
+    channel_secret: ${LINE_CHANNEL_SECRET}
+    allowed_user_ids:
+      - ${LINE_ADMIN_USER_ID}
+```
+
+### SimpleX Chat
+
+SimpleX is the privacy-first choice: no global user IDs, no central identity graph. That is good for privacy and harder for ops. Require pairing, persist local contact labels, and do not use it as the only approval channel until restore/backup is tested.
+
+```yaml
+gateways:
+  simplex:
+    enabled: true
+    profile: simplex-admin
+    require_pairing: true
+    trust_label: medium
+```
 
 ### Google Chat
 
-Google Chat is the cleanest v0.13 choice for Google Workspace teams that do not want a separate Slack/Discord surface. Treat spaces as group chats: use allowlists, never approve sensitive actions in the same room that requested them, and route production approvals to a private admin DM/channel.
+Google Chat is the cleanest Workspace choice for Google Workspace teams that do not want a separate Slack/Discord surface. Treat spaces as group chats: use allowlists, never approve sensitive actions in the same room that requested them, and route production approvals to a private admin DM/channel.
 
 Typical posture:
 
@@ -70,19 +117,6 @@ Use QQBot when your community already lives in QQ and you want the same approval
 
 Yuanbao is now a native gateway adapter with text and media delivery. It belongs in the same bucket as Weixin/WeCom: powerful in China/APAC workflows, but operationally different from Western SaaS bots. Verify media size limits and identity mapping before using it for production approvals.
 
-### Microsoft Teams Plugin
-
-Teams proves the v0.12 gateway-plugin architecture: new platforms no longer need to land inside `gateway/platforms/` to be usable. Enable only trusted platform plugins:
-
-```bash
-hermes plugins list
-hermes plugins enable teams
-hermes gateway setup
-```
-
-Keep project-local plugins disabled unless the repository is trusted (`HERMES_ENABLE_PROJECT_PLUGINS=true` is intentionally opt-in).
-
----
 
 ## iMessage via BlueBubbles
 

--- a/part16-backup-debug.md
+++ b/part16-backup-debug.md
@@ -143,7 +143,7 @@ When something goes weird, the old flow was: grep through `~/.hermes/logs/`, pas
 ```text
 You → /debug
   Collecting diagnostics…
-  ✓ Agent version: v0.13.0 (v2026.5.7)
+  ✓ Agent version: v0.14.0 (v2026.5.16)
   ✓ Platform: Linux 6.8.0 / Python 3.12.3
   ✓ Gateway: running (3 adapters connected)
   ✓ Last 200 lines of agent.log
@@ -229,9 +229,9 @@ Preserves detail relevant to the topic and aggressively compresses everything el
 
 A handful of hardening changes landed in the "everywhere" + "gateway" releases worth calling out explicitly:
 
-### v0.13 redaction + hardline blocklist
+### v0.13+ redaction + hardline blocklist
 
-Hermes v0.13 turns secret redaction on by default and keeps the hardline blocklist for commands that should not be recoverable through casual approval prompts. Keep your own denylist too, but do not rely on "the model will know this is dangerous" for commands that delete homes, scrape credentials, or hit metadata services.
+Hermes v0.13+ turns secret redaction on by default and keeps the hardline blocklist for commands that should not be recoverable through casual approval prompts. Keep your own denylist too, but do not rely on "the model will know this is dangerous" for commands that delete homes, scrape credentials, or hit metadata services.
 
 Useful custom denylist additions:
 
@@ -307,7 +307,7 @@ You've now seen the backup/debug slice of the current feature surface:
 - [Part 12 — Web Dashboard](./part12-web-dashboard.md)
 - [Part 13 — Nous Tool Gateway](./part13-tool-gateway.md)
 - [Part 14 — Fast Mode & Background Watchers](./part14-fast-mode-watchers.md)
-- [Part 15 — New Platforms (iMessage, WeChat, Android)](./part15-new-platforms.md)
+- [Part 15 — New Platforms (Teams, LINE, SimpleX, iMessage, WeChat, Android)](./part15-new-platforms.md)
 - [Part 23 — Tenacity Stack](./part23-tenacity-stack.md)
 
-If you installed fresh on v0.13.0 and walked through [Part 1](./part1-setup.md) and this series, you're running the most capable Hermes configuration to date.
+If you installed fresh on v0.14.0 and walked through [Part 1](./part1-setup.md) and this series, you're running the most capable Hermes configuration to date.

--- a/part18-coding-agents.md
+++ b/part18-coding-agents.md
@@ -10,11 +10,11 @@ Hermes is excellent at reasoning, memory, conversation, and workflow. It is *not
 
 | Agent | Strengths | Auth model |
 |-------|-----------|------------|
-| **Claude Code** | Best unattended PR work, large refactors, tests, reviews; pair with Sonnet 5/Opus 4.7 | Pro/Max OAuth or `ANTHROPIC_API_KEY` |
-| **Codex** (OpenAI) | Fast sandboxed feedback loop, bug hunts, small/medium edits; strong with GPT-5.5/Codex models | OAuth via `openai` CLI or `OPENAI_API_KEY` |
-| **Gemini CLI** | 1M context and multimodal repo/document sweeps; strongest "read everything first" lane | OAuth via `gemini auth`; Hermes' own Gemini OAuth covers normal model-provider use |
+| **Claude Code** | Best unattended PR work, large refactors, tests, reviews; Week 20+ agent view, `/goal`, and fast Opus 4.7 mode make it the premium lane | Pro/Max OAuth or `ANTHROPIC_API_KEY` |
+| **Codex** (OpenAI) | Fast sandboxed feedback loop, bug hunts, small/medium edits; v0.133+ goals default well and runs cleanly behind `hermes proxy` | OAuth via `openai` CLI, `OPENAI_API_KEY`, or `hermes proxy` |
+| **Gemini CLI** | 1M context and multimodal repo/document sweeps; v0.43 improves surgical edits, session import/export, and OAuth behavior on headless Linux | OAuth via `gemini auth`; Hermes' own Gemini OAuth covers normal model-provider use |
 | **OpenCode** (anomalyco) | Open-source, routes to Kimi K2.6 / GLM / MiMo cheaply | Bring any provider key |
-| **Aider** | Surgical git-based edits, smallest token footprint | Bring any provider key |
+| **Aider** | Surgical git-based edits, smallest token footprint; works well through `hermes proxy` | Bring any provider key or local proxy |
 
 Hermes keeps state, memory, conversation, approvals, Kanban lifecycle, and platform integration; each specialist does what it does best. You get one control plane, many agents.
 
@@ -165,6 +165,16 @@ From that point:
 The same binding works for Codex, Gemini CLI, OpenCode, and any ACP-compatible coding agent.
 
 **Remote execution bonus:** combine with the [remote sandbox feature](./part21-remote-sandboxes.md) and the coding agent runs on a Modal/Daytona/SSH host — your phone drives, a beefy remote does the work.
+
+---
+
+## Agent Tooling Updates (May 25, 2026)
+
+- **Claude Code Week 20+**: agent view, `/goal`, and faster Opus 4.7 make it the best premium worker lane for high-stakes PRs.
+- **Codex v0.133+**: goals are enabled by default; point it at `hermes proxy` when you want ChatGPT/Codex OAuth without another API key.
+- **Gemini CLI v0.43**: better surgical edit steering, session export/import, and headless OAuth fixes make it safer as a repo-scale reader.
+- **Zed ACP Registry**: v0.14 exposes Hermes through `uvx`/ACP so Zed and other ACP-aware editors can drive Hermes directly.
+- **Aider/Cline/Continue**: all benefit from `hermes proxy` because they only need an OpenAI-compatible base URL.
 
 ---
 

--- a/part19-security-playbook.md
+++ b/part19-security-playbook.md
@@ -106,9 +106,9 @@ security:
     # DO NOT ADD: any subagent that reads Telegram, email, webhooks, or scraped web
 ```
 
-### v0.13 Security Defaults
+### v0.13+ Security Defaults
 
-Hermes v0.13 closed another security wave, including 8 P0s. Update your threat model:
+Hermes v0.13 closed a major security wave, including 8 P0s. Update your threat model:
 
 - **Secret redaction is ON by default.** Do not disable it for "cleaner logs." If you explicitly opt out, treat logs/debug bundles as secret-bearing artifacts.
 - **Discord role allowlists are guild-scoped.** Re-check any config that reused role IDs across servers; cross-guild role assumptions were the dangerous part.
@@ -129,7 +129,7 @@ security:
   secrets:
     scope: per_tool                  # Env vars only inject into the tool that declared them
     redaction:
-      enabled: true                  # Default in v0.13; keep it explicit in hardened configs
+      enabled: true                  # Default in v0.13+; keep it explicit in hardened configs
       patterns:
         - "sk-[a-zA-Z0-9]{20,}"      # OpenAI-style keys
         - "xoxb-[0-9-a-f]{20,}"      # Slack bot tokens

--- a/part20-observability.md
+++ b/part20-observability.md
@@ -1,6 +1,6 @@
 # Part 20: Observability & Cost Control — Langfuse, Helicone, Kanban, /usage, Routing Playbooks
 
-*You can't optimize what you can't see. Hermes tracks tokens, latency, and errors natively, but once you're running across CLI + Telegram + Discord + Google Chat + cron + Kanban worker lanes, you want a real tracing stack. This part sets up Langfuse, Helicone, or OpenTelemetry → Phoenix with one config block, then gives you the cost-routing playbook that dropped our test deployment from $34 to $3 per feature implementation.*
+*You can't optimize what you can't see. Hermes tracks tokens, latency, and errors natively, but once you're running across CLI + Telegram + Discord + Google Chat + LINE + SimpleX + Teams + cron + Kanban worker lanes, you want a real tracing stack. This part sets up Langfuse, Helicone, or OpenTelemetry → Phoenix with one config block, then gives you the cost-routing playbook that dropped our test deployment from $34 to $3 per feature implementation.*
 
 ---
 
@@ -186,7 +186,7 @@ Most Hermes cost bloat comes from using your most expensive frontier model for t
 ```yaml
 model_routing:
   default:
-    model: claude-sonnet
+    model: claude-sonnet-5
     provider: anthropic
   routes:
     - match: { intent: [classification, extraction, triage, sum_under_500_tokens] }
@@ -199,7 +199,7 @@ model_routing:
       model: glm
       provider: zai
     - match: { intent: [write_code, refactor, debug], complexity: high }
-      model: claude-sonnet
+      model: claude-sonnet-5
       provider: anthropic
     - match: { intent: [reasoning, math], complexity: high }
       model: reasoning
@@ -228,7 +228,20 @@ prompt_caching:
   min_cache_tokens: 1024             # Anthropic's minimum
 ```
 
-Anthropic's prompt caching discount is ~90% on cached reads. For a 5K-token system prompt used 100 times a day, that's a real $2–5 a day saved.
+v0.14 extends Claude prompt-prefix caching across sessions for up to 1 hour, so repeated skills/SOUL/memory prefixes get faster and cheaper after `/new` too. Anthropic's prompt caching discount is ~90% on cached reads. For a 5K-token system prompt used 100 times a day, that's a real $2–5 a day saved.
+
+### Rule 2B: Track Browser/CDP Latency Separately
+
+v0.14's persistent CDP path makes browser-console and dashboard automation much faster, but only if you can see when it falls back to cold browser startup. Add a browser lane to traces when you rely on computer/browser tools:
+
+```yaml
+telemetry:
+  spans:
+    browser_cdp: true
+    computer_use: true
+```
+
+Alert on repeated cold CDP starts; it usually means Chrome died, the profile changed, or a sandbox reset removed the persisted connection.
 
 ### Rule 3: Use Fast Mode Surgically
 
@@ -299,7 +312,7 @@ hermes evals dataset create telegram-support-flows
 hermes evals dataset add telegram-support-flows ~/.hermes/traces/support/*.json
 
 # Run on every release
-hermes evals run telegram-support-flows --model anthropic/claude-sonnet
+hermes evals run telegram-support-flows --model anthropic/claude-sonnet-5
 hermes evals run telegram-support-flows --model zai/glm     # Check if cheaper model still passes
 hermes evals compare
 ```

--- a/part22-latest-power-moves.md
+++ b/part22-latest-power-moves.md
@@ -1,6 +1,6 @@
 # Part 22: Latest Power Moves — Curator, TUI, Plugins, Context Files
 
-*If you already know Hermes but missed the v0.11/v0.12 wave, read this part first for Curator, TUI, plugins, and context hygiene. For the v0.13 durability layer — Kanban, `/goal`, Checkpoints v2, and no-agent cron — go next to [Part 23](./part23-tenacity-stack.md).*
+*If you already know Hermes but missed the v0.11/v0.12 wave, read this part first for Curator, TUI, plugins, and context hygiene. For the v0.13/v0.14 durability + foundation layer — Kanban, `/goal`, `/handoff`, Checkpoints v2, no-agent cron, PyPI installs, proxy, and new platforms — go next to [Part 23](./part23-tenacity-stack.md).*
 
 ---
 
@@ -161,7 +161,7 @@ Then:
 4. Run `hermes curator run --dry-run`.
 5. Test one gateway message, one tool call, one skill, and one cron job.
 6. Review [Part 19](./part19-security-playbook.md) before enabling broad platform access.
-7. Then run the [v0.13 Tenacity checklist](./part23-tenacity-stack.md#8-upgrade-checklist-from-v012-to-v013).
+7. Then run the [v0.14 Foundation checklist](./part23-tenacity-stack.md#8-upgrade-checklist-from-v013-to-v014).
 
 ---
 

--- a/part23-tenacity-stack.md
+++ b/part23-tenacity-stack.md
@@ -1,6 +1,6 @@
-# Part 23: Tenacity Stack — Kanban, Goals, Checkpoints v2, No-Agent Cron
+# Part 23: Foundation + Tenacity Stack — Kanban, Goals, Handoff, Proxy, No-Agent Cron
 
-*Hermes v0.13.0 (2026.5.7, "The Tenacity Release") changed the best-practice stack again. The move is no longer "spawn more subagents"; it is "put durable work on a board, lock important sessions to a goal, checkpoint aggressively, and remove the LLM from jobs that do not need one."*
+*Hermes v0.14.0 (2026.5.16, "The Foundation Release") does not replace the v0.13 Tenacity stack — it makes it easier to install, cheaper to run, and available from more surfaces. The move is now: install lean, put durable work on Kanban, lock sessions to `/goal`, hand off live when the model/profile should change, and keep deterministic jobs out of the LLM path.*
 
 ---
 
@@ -25,7 +25,7 @@ Then create work from chat, CLI, or the dashboard:
 
 Why this matters:
 
-| Old pattern | v0.13 pattern |
+| Old pattern | v0.14 pattern |
 |-------------|---------------|
 | Parent subagent blocks until child returns | Board row persists; parent can move on |
 | Failed child disappears into logs | Task blocks with comments, retry budget, and history |
@@ -72,7 +72,7 @@ Keep Hermes Kanban as the source of truth. Do not let a specialist CLI silently 
 `/goal` gives a session a persistent objective. After each turn, Hermes checks whether the goal is satisfied; if not, it continues within the configured turn budget.
 
 ```text
-/goal Refresh this guide to Hermes v0.13, remove stale v0.12-as-current claims, run validation, and open a PR.
+/goal Refresh this guide to Hermes v0.14, remove stale v0.13-as-current claims, run validation, and open a PR.
 ```
 
 Use it for:
@@ -88,7 +88,7 @@ Do not use `/goal` for vague aspirations like "improve the project." Give it an 
 
 ## 4. Checkpoints v2 Changes Your Risk Model
 
-Hermes already had rollback-style safety. v0.13's Checkpoints v2 makes it more production-worthy:
+Hermes already had rollback-style safety. v0.13's Checkpoints v2 remains the production baseline:
 
 - Real pruning prevents checkpoint directories from growing forever.
 - Disk guardrails stop runaway snapshots from filling a VPS.
@@ -109,7 +109,7 @@ This is especially important when Kanban workers use git worktrees: checkpoints 
 
 ## 5. Use `no_agent` Cron for Watchdogs
 
-Not every scheduled job needs an LLM. v0.13 cron can run in **no-agent mode**: execute a script on schedule, deliver stdout if there is anything to say, and spend zero tokens.
+Not every scheduled job needs an LLM. v0.13+ cron can run in **no-agent mode**: execute a script on schedule, deliver stdout if there is anything to say, and spend zero tokens.
 
 Use no-agent mode for:
 
@@ -136,7 +136,7 @@ Keep LLM-backed cron for jobs that need judgment, synthesis, or tool use. Use no
 
 ## 6. Route Media to Models That Actually Understand It
 
-v0.13 adds a `video_analyze` tool path for Gemini and compatible multimodal providers. Do not treat video as "just another attachment" on a text model.
+v0.13+ adds a `video_analyze` tool path for Gemini and compatible multimodal providers. Do not treat video as "just another attachment" on a text model.
 
 Use it for:
 
@@ -172,10 +172,10 @@ Keep cloned voices private-channel only unless you have explicit consent and a c
 
 ## 7. Update Your Platform and Provider Mental Model
 
-v0.13 pushes two plugin surfaces forward:
+v0.14 pushes the plugin/provider surfaces further:
 
-- **Platforms:** Google Chat becomes the 20th messaging platform, and platform adapters can ship as plugins without touching core.
-- **Providers:** model providers can ship as plugins through the provider profile surface, so "wait for core support" is less of a blocker.
+- **Platforms:** Google Chat is joined by Teams end-to-end, LINE, and SimpleX Chat, bringing the gateway to 22+ platforms.
+- **Providers:** model providers can ship as plugins, SuperGrok OAuth is first-class, and `hermes proxy` can expose OAuth-backed providers through an OpenAI-compatible local endpoint.
 
 Operational rule:
 
@@ -186,27 +186,27 @@ Operational rule:
 
 ---
 
-## 8. Upgrade Checklist from v0.12 to v0.13
+## 8. Upgrade Checklist from v0.13 to v0.14
 
 ```bash
 hermes update --check
 hermes backup
 hermes --version
-hermes curator run --dry-run
+pip install -U hermes-agent
 hermes plugins list
 hermes model
+hermes proxy --help
 ```
 
-Then verify the v0.13-specific paths:
+Then verify the v0.14-specific paths:
 
-- Create a throwaway Kanban card and dispatch one worker.
-- Set and clear a `/goal` in a disposable session.
-- Make a harmless file edit and confirm checkpoint/rollback behavior.
-- Restart the gateway mid-conversation and verify auto-resume.
-- Check that secret redaction is on by default in logs, debug bundles, and gateway replies.
-- If you use Discord/WhatsApp, re-check guild/channel/user allowlists.
-- Replace pure status-check LLM crons with `no_agent` jobs.
-- If you expose Google Chat, treat it like any other untrusted group surface until allowlists are proven.
+- Confirm `pip install hermes-agent` or your source install resolves without pulling unused heavy adapters.
+- Sign in to SuperGrok/Claude/OpenAI OAuth only if you use those subscriptions, then test `hermes proxy` on loopback.
+- Run an `x_search` query from a disposable session if you rely on X/Twitter signals.
+- If you use Teams, verify Graph auth, webhook receipt, and outbound delivery end-to-end.
+- If you expose LINE or SimpleX, keep them in a quarantine profile until identity and approval routing are proven.
+- Use `/handoff` in a disposable session to move from a cheap model to a deep-reasoning profile without losing context.
+- Re-check the v0.13 durability paths too: Kanban, `/goal`, Checkpoints v2, no-agent cron, and redaction defaults.
 
 ---
 
@@ -214,15 +214,15 @@ Then verify the v0.13-specific paths:
 
 For a serious May 2026 Hermes deployment:
 
-1. **Dashboard** for config, plugins, Kanban, analytics, profiles, and Chat.
-2. **Kanban** for durable multi-agent work.
-3. **`/goal`** for single-session persistence.
-4. **Curator** for skill-library hygiene.
-5. **LightRAG or a memory provider plugin** for cross-session recall.
-6. **MCP** for tools, with strict trust and sampling boundaries.
-7. **Coding-agent lanes** for code work, not one giant Hermes prompt.
-8. **Remote sandboxes/worktrees** for isolation.
-9. **Langfuse/Helicone/Phoenix** for traces and cost control.
-10. **No-agent cron** for deterministic watchdogs.
+1. **PyPI/source install with lazy deps** so the box only carries adapters it actually uses.
+2. **Dashboard** for config, plugins, Kanban, analytics, profiles, and Chat.
+3. **Kanban** for durable multi-agent work.
+4. **`/goal` + `/handoff`** for persistent objectives and live model/profile escalation.
+5. **`hermes proxy`** for Codex/Aider/Cline/Continue using OAuth-backed subscriptions.
+6. **Grok 4.3 / Gemini 3.1** for million-token research and media lanes.
+7. **MCP** for tools, with strict trust and sampling boundaries.
+8. **Coding-agent lanes** for code work, not one giant Hermes prompt.
+9. **Remote sandboxes/worktrees** for isolation.
+10. **Langfuse/Helicone/Phoenix + no-agent cron** for traces, budgets, and deterministic watchdogs.
 
-If you only adopt one new pattern from v0.13, adopt Kanban. It is the difference between "an agent tried something" and "a system of agents completed auditable work."
+If you only adopt one durability pattern, adopt Kanban. If you only adopt one v0.14 pattern, adopt `hermes proxy` for OAuth-backed coding tools and keep it loopback-only.

--- a/part3-lightrag-setup.md
+++ b/part3-lightrag-setup.md
@@ -73,8 +73,8 @@ Create `~/.hermes/lightrag/.env`:
 ```bash
 # LLM for entity extraction (during ingestion)
 LLM_BINDING=openai
-LLM_MODEL=gpt-4.1-mini
-LLM_BINDING_API_KEY=<your-openai-api-key>
+LLM_MODEL=google/gemini-3.1-flash
+LLM_BINDING_API_KEY=<your-gemini-api-key-or-oauth-token>
 
 # Embedding model (for vector storage)
 EMBEDDING_BINDING=fireworks
@@ -391,7 +391,7 @@ cd ~/.hermes/lightrag/LightRAG && lightrag-server --port 9623
 ### Slow ingestion
 
 Entity extraction is LLM-bound. Speed it up:
-- Use a faster model for ingestion (GPT-4.1-mini, Claude Haiku)
+- Use a faster model for ingestion (Gemini 3.1 Flash, Kimi K2.6, or Claude Haiku)
 - Process documents in parallel batches
 - Use a local model if you have GPU capacity
 

--- a/part4-telegram-setup.md
+++ b/part4-telegram-setup.md
@@ -1,12 +1,12 @@
 # Part 4: Telegram Setup (Chat From Anywhere)
 
-*Connect Hermes to Telegram for mobile access, voice memos, group chats, and scheduled task delivery. This is the most battle-tested of the 20+ messaging adapters — start here, branch out to the others as needed.*
+*Connect Hermes to Telegram for mobile access, voice memos, group chats, and scheduled task delivery. This is the most battle-tested of the 22+ messaging adapters — start here, branch out to the others as needed.*
 
 ---
 
-## The 20+ Platform Gateway
+## The 22+ Platform Gateway
 
-As of v0.13.0 (May 2026), the Hermes gateway ships adapters/plugins for **20+ platforms**. They all share the same session DB, the same `/fast` toggle, the same Tool Gateway plumbing, and the same cron delivery mechanism:
+As of v0.14.0 (May 2026), the Hermes gateway ships adapters/plugins for **22+ platforms**. They all share the same session DB, the same `/fast` toggle, the same Tool Gateway plumbing, and the same cron delivery mechanism. v0.14 also improves Discord history/search fetches, so large server channels are more useful as context sources instead of one-message-only triggers.
 
 | Flagship | New in v0.9 | Enterprise / regional | Self-hosted / generic |
 |----------|-------------|-----------------------|-----------------------|
@@ -14,11 +14,11 @@ As of v0.13.0 (May 2026), the Hermes gateway ships adapters/plugins for **20+ pl
 | Discord | WeChat / Weixin | Feishu / Lark | Matrix |
 | Slack | WeCom | Mattermost | SMS (Twilio) |
 | Google Chat | QQBot | Microsoft Teams | Email (IMAP+SMTP) |
-| WhatsApp | | | |
+| LINE | SimpleX Chat | WhatsApp | |
 | | Tencent Yuanbao | | Home Assistant |
 | | | | Webhook (generic) |
 
-- For **iMessage, WeChat, and Android/Termux**, see [Part 15](./part15-new-platforms.md).
+- For **LINE, SimpleX, Teams, iMessage, WeChat, and Android/Termux**, see [Part 15](./part15-new-platforms.md).
 - For **gateway crash recovery** and health checks across all platforms, see [Part 11](./part11-gateway-recovery.md).
 - For the browser UI that manages every platform's state, see [Part 12](./part12-web-dashboard.md).
 

--- a/part9-custom-models.md
+++ b/part9-custom-models.md
@@ -1,14 +1,14 @@
 # Part 9: Custom Model Providers (Use Any Model You Want)
 
-*Hermes supports any OpenAI-compatible API, plus first-class native adapters for Nous Portal, Anthropic, OpenAI/Codex, OpenRouter, AWS Bedrock, Azure AI Foundry, Google Gemini, Gemini OAuth, LM Studio, xAI, Xiaomi MiMo, Kimi/Moonshot, z.ai/GLM, MiniMax, Arcee, GMI Cloud, Tencent TokenHub, Hugging Face, Cerebras, Groq, Fireworks, Vercel AI Gateway, Ollama, and provider plugins. This is the May 14, 2026 cheat sheet.*
+*Hermes supports any OpenAI-compatible API, plus first-class native adapters for Nous Portal, Anthropic, OpenAI/Codex, OpenRouter, AWS Bedrock, Azure AI Foundry, Google Gemini, Gemini OAuth, LM Studio, xAI, Xiaomi MiMo, Kimi/Moonshot, z.ai/GLM, MiniMax, Arcee, GMI Cloud, Tencent TokenHub, Hugging Face, Cerebras, Groq, Fireworks, Vercel AI Gateway, Ollama, and provider plugins. This is the May 25, 2026 cheat sheet.*
 
-> **What's new since the v0.12 guide refresh** — v0.13 makes providers pluggable, adds media-aware routing such as `video_analyze`, improves MCP media handling, keeps Gemini OAuth inside `hermes model`, and makes OpenRouter/Nous/Vercel model pickers rely on live manifests instead of hardcoded release snapshots.
+> **What's new since the v0.13 guide refresh** — v0.14 adds SuperGrok OAuth with Grok 4.3 at 1M context, `hermes proxy` for OpenAI-compatible access to OAuth-backed Claude/ChatGPT/SuperGrok subscriptions, first-class `x_search`, cross-session 1-hour Claude prompt caching, OpenRouter Pareto Code routing, and provider-agnostic `computer_use` support.
 
 ---
 
 ## Native Adapters vs Generic OpenAI-Compatible
 
-As of v0.13.0 (May 2026), Hermes ships **native adapters** for a large provider set, plus a provider-plugin surface for out-of-tree backends. Native adapters know about provider-specific features that a generic OpenAI-compatible wrapper can't:
+As of v0.14.0 (May 2026), Hermes ships **native adapters** for a large provider set, plus a provider-plugin surface for out-of-tree backends. Native adapters know about provider-specific features that a generic OpenAI-compatible wrapper can't:
 
 | Provider | Native adapter? | Notable feature |
 |----------|-----------------|-----------------|
@@ -19,7 +19,7 @@ As of v0.13.0 (May 2026), Hermes ships **native adapters** for a large provider 
 | **AWS Bedrock** | Yes | Converse API, IAM credentials, cross-region inference profiles, Bedrock Guardrails |
 | **Azure AI Foundry** | Yes | Auto-detects OpenAI-style vs Anthropic-style deployments and context length |
 | **LM Studio** | Yes | Local `/models` discovery, optional auth, reasoning transport, `hermes doctor` checks |
-| **xAI (Grok)** | Yes | Native live X search and xAI image/STT/TTS integrations, including Custom Voices |
+| **xAI / SuperGrok** | Yes | SuperGrok OAuth, Grok 4.3 1M context, `x_search`, and xAI image/STT/TTS integrations including Custom Voices |
 | **Xiaomi MiMo** | Yes | Native reasoning modes (`low`/`medium`/`high`) exposed as config |
 | **Kimi / Moonshot** | Yes | 200K+ context, great for LightRAG entity extraction (see [Part 3](./README.md#part-3-lightrag--graph-rag-that-actually-works)) |
 | **z.ai / GLM** | Yes | Strong open-weight tool-use models; good cheap fallback for planning/exploration |
@@ -39,9 +39,31 @@ As of v0.13.0 (May 2026), Hermes ships **native adapters** for a large provider 
 | **Provider plugin** | Plugin | Drop in a `ProviderProfile` without patching Hermes core |
 | **Anything else** | Generic | Any OpenAI-compatible `base_url` |
 
+### SuperGrok OAuth + Grok 4.3
+
+v0.14 makes xAI a first-class Hermes provider instead of just another OpenAI-compatible key. Use SuperGrok OAuth when you already pay for it; use `XAI_API_KEY` for service-account automation. Grok 4.3 is the live-search/default-current-events lane now because it combines 1M context, X-native retrieval, and voice/image integrations.
+
+```bash
+hermes model     # choose xAI / SuperGrok OAuth
+```
+
+```yaml
+models:
+  research_live:
+    provider: xai
+    model: grok-4.3
+    context_tokens: 1048576
+tools:
+  x_search:
+    enabled: true
+    auth: oauth
+```
+
+Keep it out of cheap cron loops; route it explicitly for live events, X threads, and million-token synthesis.
+
 Pick the native adapter when one exists — you get the provider-specific features for free. Fall back to the generic OpenAI-compatible path only for endpoints that don't have a native adapter yet.
 
-### Provider Cheat Sheet (May 14, 2026)
+### Provider Cheat Sheet (May 25, 2026)
 
 The exact "best model" moves weekly, so treat this as a routing posture rather than a leaderboard. Use `hermes model` for live picker data, then pin only what you need reproducible.
 
@@ -49,12 +71,12 @@ The exact "best model" moves weekly, so treat this as a routing posture rather t
 |------|------------|-----|
 | Default coding / refactors | Anthropic Sonnet 5, Claude Code, or Codex OAuth | Best reliability for patch-heavy work; Codex OAuth avoids API-key churn |
 | Deep reasoning / high stakes | GPT-5.5 reasoning or Anthropic Opus 4.7 | Use explicitly; do not make it the default for cron/bulk tasks |
-| Long-context repo or document reads | Gemini 3.1 Pro/Flash or OpenRouter equivalent | Huge window, cheap enough for map/reduce, video, and summarization |
+| Long-context repo or document reads | Gemini 3.1 Pro/Flash, Grok 4.3, or OpenRouter equivalent | Huge window, cheap enough for map/reduce, video, and summarization |
 | Cheap daily driver | Gemini OAuth + Kimi K2.6 + z.ai/GLM | Good quality/cost mix, especially with auxiliary routing |
 | Enterprise / VPC / compliance | AWS Bedrock or Azure AI Foundry | IAM/Azure auth, guardrails, private deployments, audit controls |
 | Local/privacy/offline | LM Studio or Ollama | No cloud egress; great for extraction, embeddings, and drafts |
 | Ultra-fast interactive turns | Cerebras or Groq | Very high tokens/sec; useful for classification and short-form chat |
-| Current-events search | xAI Grok 4.x or tool-backed web search | Grok has native live-X search; Tool Gateway can cover broader web |
+| Current-events / X search | xAI Grok 4.3, `x_search`, or tool-backed web search | Grok has native live-X search; Tool Gateway can cover broader web |
 
 > Pricing and context windows change too quickly to hardcode. Hermes now pulls OpenRouter and Nous Portal picker lists from a remote manifest, while provider APIs supply pricing/context metadata where available.
 
@@ -136,7 +158,7 @@ Models are configured in `~/.hermes/config.yaml`:
 
 ```yaml
 # Default model
-model: claude-sonnet
+model: claude-sonnet-5
 provider: anthropic
 
 # Provider configurations
@@ -161,6 +183,7 @@ providers:
 
   xai:
     api_key: ${XAI_API_KEY}
+    oauth_enabled: true               # SuperGrok OAuth when available
     live_search: true                 # Grok's live X/Twitter search
 
   xiaomi:
@@ -229,7 +252,7 @@ Add aliases to switch models without typing full names:
 ```yaml
 model_aliases:
   fast:
-    model: cerebras/llama-3.3-70b
+    model: cerebras/qwen-3-32b
     provider: cerebras
   smart:
     model: claude-opus-4.7
@@ -242,7 +265,7 @@ model_aliases:
 Use in chat:
 
 ```
-/model fast      # Switch to Cerebras Llama 70B
+/model fast      # Switch to Cerebras Qwen 3 32B
 /model smart     # Switch to Claude Opus
 /model local     # Switch to local Ollama model
 ```
@@ -265,12 +288,12 @@ Use these as opinionated defaults, then tune with [Part 20's cost-routing playbo
 
 | Task | First choice | Fallback (cheaper) | Fallback (fastest) |
 |------|--------------|--------------------|--------------------|
-| Daily conversation | Anthropic Sonnet 5 | Gemini OAuth or z.ai/GLM | Cerebras Llama/Qwen |
+| Daily conversation | Anthropic Sonnet 5 | Gemini OAuth or z.ai/GLM | Cerebras Qwen 3 |
 | Coding delegation | Claude Code / Codex OAuth | OpenCode + Kimi K2.6 | OpenCode + Cerebras |
 | Long-context reads (>200K) | Gemini 3.1 Pro | Gemini Flash | — |
 | Classification / triage | Gemini Flash | Cerebras Qwen3 32B | Arcee AFM-4.5 |
 | Reasoning (math, planning) | GPT-5.5 reasoning | Anthropic Opus 4.7 | z.ai/GLM |
-| Current events / live search | xAI Grok 4.x | Gemini with grounding | Tool Gateway web search |
+| Current events / live search | xAI Grok 4.3 + `x_search` | Gemini with grounding | Tool Gateway web search |
 | Embeddings (LightRAG) | Qwen3-Embedding-8B (Fireworks) | nomic-embed-text (Ollama) | OpenAI `text-embedding-3-small` |
 | TTS (Telegram voice) | xAI Custom Voices or Tool Gateway TTS | Gemini Flash TTS | Edge TTS (free) |
 | Vision / video | Gemini 3.1 Pro/Flash | GPT-5.5 multimodal | Claude Sonnet 5 |
@@ -293,7 +316,7 @@ providers:
   cerebras:
     api_key: ${CEREBRAS_API_KEY}
     base_url: https://api.cerebras.ai/v1
-    # Models: llama-3.3-70b, llama-4-scout-17b-16e-instruct, qwen-3-32b
+    # Models: qwen-3-32b, llama-4-scout-17b-16e-instruct
 ```
 
 ## Local Models (Ollama)
@@ -325,7 +348,7 @@ embedding:
 ## Switching at Runtime
 
 ```
-/model cerebras/llama-3.3-70b    # Full model path
+/model cerebras/qwen-3-32b      # Full model path
 /model fast                       # Alias
 /model                            # Show current model
 ```
@@ -354,7 +377,7 @@ auxiliary_models:
   # Use a fast cheap model for compression — it's just summarizing
   compression:
     provider: cerebras
-    model: llama-3.3-70b
+    model: qwen-3-32b
     timeout: 30
 
   # Use a multimodal model for image/video analysis
@@ -391,7 +414,7 @@ Configure automatic fallback if the primary model fails:
 ```yaml
 model_fallback:
   - provider: cerebras
-    model: llama-3.3-70b
+    model: qwen-3-32b
   - provider: openrouter
     model: anthropic/claude-sonnet-5
   - provider: local

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,7 +33,7 @@ hermes /reload
 | **security** | `rotate-secrets` | Rotates webhook HMACs, API keys, and OAuth tokens; updates `.env` and restarts gateways |
 | **security** | `audit-approval-bypass` | Audits which subagents currently bypass approval and whether they handle untrusted input |
 | **ops** | `nightly-backup` | `hermes backup`, uploads encrypted copy to configured storage, prunes old backups |
-| **ops** | `weekly-dep-audit` | Uses Gemini 2.5 Pro + GitHub MCP to audit dependencies across configured repos |
+| **ops** | `weekly-dep-audit` | Uses Gemini 3.1 Pro + GitHub MCP to audit dependencies across configured repos |
 | **ops** | `cost-report` | Generates a weekly LLM-cost breakdown by provider / gateway / skill, posts to your private DM |
 | **ops** | `telegram-triage` | Classifies inbound Telegram DMs, autoreplies low-stakes, escalates high-stakes to you |
 | **dev** | `pr-review` | Delegates a PR review to Claude Code with a scoped read-only GitHub PAT |

--- a/skills/dev/pr-review/SKILL.md
+++ b/skills/dev/pr-review/SKILL.md
@@ -38,7 +38,7 @@ Pulls a PR, hands it to Claude Code with a minimal read-only tool set, posts str
 3. **Decide depth:**
    - `quick`: title + description only, ≤ 200 tokens of review
    - `standard`: full diff, up to 5 issues flagged
-   - `deep`: full diff + repo context (via Gemini 2.5 Pro for 1M-context ingest), up to 15 issues + architectural comments
+   - `deep`: full diff + repo context (via Gemini 3.1 Pro for 1M-context ingest), up to 15 issues + architectural comments
 
 4. **Delegate to Claude Code** with write tools **disabled**:
    ```yaml

--- a/skills/ops/cost-report/SKILL.md
+++ b/skills/ops/cost-report/SKILL.md
@@ -92,7 +92,9 @@ Generate a human-readable (or machine-readable) cost report from Hermes' usage l
 5. **Recommend savings.** Pattern-match the data:
    - Any single skill > 30% of weekly cost → suggest a cheaper model for that skill
    - Input tokens > 10x output tokens on any provider → suggest prompt caching
+   - Repeated Claude skills/SOUL prefixes without cache hits → enable v0.14 1-hour prefix caching
    - Gemini calls without `google/gemini-3.1-flash` on classification-ish intents → suggest routing
+   - Grok 4.3 / GPT-5.5 / Opus calls in cron or triage lanes → require explicit opt-in routing
 
 6. **Deliver.** Post to private notification channel. Attach the raw JSON if format is json.
 

--- a/skills/ops/telegram-triage/SKILL.md
+++ b/skills/ops/telegram-triage/SKILL.md
@@ -18,7 +18,7 @@ Front-line filter for public-facing Telegram bots. Runs cheap classification, an
 
 ## Procedure
 
-1. **Classify.** Use a cheap model (Gemini 2.5 Flash) to assign one of:
+1. **Classify.** Use a cheap model (Gemini 3.1 Flash) to assign one of:
    - `greeting` — "hi", "yo", "whats up"
    - `faq` — commonly asked question (list below)
    - `support` — bug report, complaint, feature request

--- a/skills/security/spam-trap/SKILL.md
+++ b/skills/security/spam-trap/SKILL.md
@@ -21,7 +21,7 @@ security:
     This skill IS the untrusted-input filter. It must never execute the text
     it is classifying; it only labels. Every action downstream remains gated
     by approval.
-model_hint: cerebras/llama-3.3-70b
+model_hint: cerebras/qwen-3-32b
 ---
 
 # spam-trap — First-line Filter
@@ -35,7 +35,7 @@ Runs on every inbound message from a low-trust gateway. Classifies and routes; n
    - Known prompt-injection markers (`ignore all previous`, ````system`, base64 blocks over 1KB, `<|im_start|>`, etc.) → `injection_attempt`
    - Rate-limit violation for sender → `spam`
 
-2. **If ambiguous**, run a cheap LLM classifier (Cerebras Llama). Prompt:
+2. **If ambiguous**, run a cheap LLM classifier (Cerebras Qwen 3). Prompt:
 
    ```
    Classify the following message into exactly one of:

--- a/templates/config/cost-optimized.yaml
+++ b/templates/config/cost-optimized.yaml
@@ -16,7 +16,7 @@ models:
   classification: cerebras/qwen-3-32b
   long_context: google/gemini-3.1-pro
   coding: moonshot/kimi-k2.6            # Fallback to Claude only for hard coding
-  coding_complex: anthropic/claude-sonnet
+  coding_complex: anthropic/claude-sonnet-5
   reasoning: zai/glm
   providers:
     google:
@@ -40,7 +40,7 @@ routing:
       model: cerebras/qwen-3-32b
     - intent: coding
       when: { complexity: high }
-      model: anthropic/claude-sonnet
+      model: anthropic/claude-sonnet-5
     - intent: coding
       model: moonshot/kimi-k2.6
     - intent: long_context

--- a/templates/config/minimum.yaml
+++ b/templates/config/minimum.yaml
@@ -12,7 +12,7 @@
 version: 1
 
 models:
-  default: anthropic/claude-sonnet
+  default: anthropic/claude-sonnet-5
   providers:
     anthropic:
       api_key: ${ANTHROPIC_API_KEY}

--- a/templates/config/production.yaml
+++ b/templates/config/production.yaml
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------
 # Full-stack, hardened, observable.
 #   - Multi-provider with task-aware routing
-#   - Telegram + Discord + Slack + Google Chat + email gateways
+#   - Telegram + Discord + Slack + Google Chat + LINE + Teams + email gateways
 #   - LightRAG + mem0 for cross-device memory
 #   - MCP: GitHub, Postgres, Cloudflare, Linear, filesystem
 #   - Langfuse tracing, cost alerts, eval hooks
@@ -14,12 +14,13 @@
 version: 1
 
 models:
-  default: anthropic/claude-sonnet
+  default: anthropic/claude-sonnet-5
   classification: google/gemini-3.1-flash
   long_context: google/gemini-3.1-pro
-  coding: anthropic/claude-sonnet
+  coding: anthropic/claude-sonnet-5
   reasoning: openai/gpt-5.5
   cheap: moonshot/kimi-k2.6
+  live_search: xai/grok-4.3
   providers:
     anthropic:
       api_key: ${ANTHROPIC_API_KEY}
@@ -35,6 +36,9 @@ models:
       api_key: ${ZAI_API_KEY}
     cerebras:
       api_key: ${CEREBRAS_API_KEY}
+    xai:
+      api_key: ${XAI_API_KEY}
+      oauth_enabled: true            # SuperGrok OAuth when available
 
 routing:
   # See Part 20 — the rules that drop spend ~90% on typical workloads
@@ -42,7 +46,7 @@ routing:
     - intent: classification
       model: google/gemini-3.1-flash
     - intent: coding
-      model: anthropic/claude-sonnet
+      model: anthropic/claude-sonnet-5
     - intent: long_context
       when: { tokens_in: { gt: 200000 } }
       model: google/gemini-3.1-pro
@@ -51,6 +55,8 @@ routing:
       model: openai/gpt-5.5
     - intent: bulk_data
       model: moonshot/kimi-k2.6
+    - intent: live_search
+      model: xai/grok-4.3
 
 gateways:
   cli: { enabled: true }
@@ -81,6 +87,26 @@ gateways:
     credentials_json: ${GOOGLE_CHAT_CREDENTIALS_JSON}
     allowed_spaces:
       - ${GOOGLE_CHAT_ADMIN_SPACE}
+    trust_label: medium
+  teams:
+    enabled: false                    # v0.14 end-to-end Graph/listener/delivery path
+    tenant_id: ${MICROSOFT_TENANT_ID}
+    client_id: ${MICROSOFT_TEAMS_CLIENT_ID}
+    client_secret: ${MICROSOFT_TEAMS_CLIENT_SECRET}
+    allowed_teams:
+      - ${MICROSOFT_TEAMS_ADMIN_TEAM}
+    trust_label: medium
+  line:
+    enabled: false
+    channel_access_token: ${LINE_CHANNEL_ACCESS_TOKEN}
+    channel_secret: ${LINE_CHANNEL_SECRET}
+    allowed_user_ids:
+      - ${LINE_ADMIN_USER_ID}
+    trust_label: medium
+  simplex:
+    enabled: false
+    profile: simplex-admin
+    require_pairing: true
     trust_label: medium
   email:
     enabled: true

--- a/templates/config/security-hardened.yaml
+++ b/templates/config/security-hardened.yaml
@@ -29,10 +29,10 @@ profiles:
           - { tool: "*", actions: [exec, write, send, create, update, delete] }
   trusted:
     description: Admin-only. Full capability.
-    models: { default: anthropic/claude-sonnet }
+    models: { default: anthropic/claude-sonnet-5 }
 
 models:
-  default: anthropic/claude-sonnet
+  default: anthropic/claude-sonnet-5
   providers:
     anthropic:
       api_key: "${ANTHROPIC_API_KEY}"
@@ -76,7 +76,7 @@ security:
     approval_channel: telegram_dm
     approval_timeout_seconds: 300       # Reject if operator doesn't respond
   secrets:
-    # Redaction is on by default in Hermes v0.13; keep patterns explicit
+    # Redaction is on by default in Hermes v0.13+; keep patterns explicit
     # for auditability and memory/log hygiene.
     redaction_patterns:
       - 'sk-[A-Za-z0-9]{40,}'

--- a/templates/config/telegram-bot.yaml
+++ b/templates/config/telegram-bot.yaml
@@ -13,7 +13,7 @@
 version: 1
 
 models:
-  default: anthropic/claude-sonnet
+  default: anthropic/claude-sonnet-5
   classification: google/gemini-3.1-flash
   providers:
     anthropic:
@@ -68,7 +68,7 @@ security:
         sampling: true
     approval_channel: telegram_dm       # Always DM, never group
   secrets:
-    # Redaction is on by default in Hermes v0.13; keep patterns explicit
+    # Redaction is on by default in Hermes v0.13+; keep patterns explicit
     # so hardened deployments know what is being scrubbed.
     redaction_patterns:
       - 'sk-[A-Za-z0-9]{40,}'           # OpenAI / Anthropic style


### PR DESCRIPTION
## Summary
Fresh May 25 pass updates the guide from the prior v0.13/Tenacity framing to Hermes v0.14.0 Foundation as the current baseline. It adds coverage for PyPI/lazy installs, SuperGrok OAuth + Grok 4.3 1M context, `hermes proxy`, `x_search`, `/handoff`, Teams end-to-end, LINE/SimpleX, native Windows beta, persistent CDP/browser improvements, and current SOTA coding-agent/model routing. It also refreshes templates, benchmarks, localized READMEs, outreach copy, reference architectures, and skills while removing stale v0.13-as-current, 20-platform, GPT-4.1/Gemini 2.5/Cerebras-Llama-era guidance.

## Type
- [x] Docs / content update
- [x] New skill (`skills/`)
- [x] New config template (`templates/config/`)
- [x] Benchmark addition
- [ ] Ecosystem entry
- [ ] Infra template (compose / caddy / systemd / script)
- [x] Fix / typo / link

## Checklist
- [x] Cross-links are relative (`./partN-foo.md`) and resolve
- [x] No secrets in any example — `${VAR}` placeholders only
- [x] Dates / prices / PR numbers are current (or marked with the date)
- [x] For skills: security notes included; `trust:` / `bypass_subagents` posture documented
- [x] For templates: every non-obvious field is commented
- [x] CHANGELOG.md updated if user-facing

## Screenshots / diffs (optional)
Docs/static-content only; no app preview or screenshots.

Link to Devin session: https://app.devin.ai/sessions/d600c4abbb09414abe9bb0a0802421d0
Requested by: @OnlyTerp