### PR TITLE
docs: add hermes-tweet ecosystem entry

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -5,6 +5,7 @@
     { "pattern": "^https://langfuse.yourdomain.com" },
     { "pattern": "^https://hermes.yourdomain.com" },
     { "pattern": "^https://hooks.yourdomain.com" },
+    { "pattern": "^https://discord.gg/" },
     { "pattern": "^http://localhost" },
     { "pattern": "^http://127.0.0.1" }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Dated list of meaningful guide updates. Roughly [Keep a Changelog](https://keepachangelog.com) flavored.
 
+## 2026-05-27 — Ecosystem Directory Update
+
+### Added
+- Hermes Tweet native plugin entry in `ECOSYSTEM.md`, applied onto current
+  `main` without reverting newer MCP / coding-agent ecosystem entries.
+
 ## 2026-05-27 — Part 20 routing schema fixes
 
 ### Fixed

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -38,6 +38,14 @@ See [Part 17](./part17-mcp-servers.md) for install patterns and trust model guid
 
 ---
 
+## Native Hermes plugins
+
+- [`hermes-tweet`](https://github.com/Xquik-dev/hermes-tweet) — X/Twitter search, reads, and gated account actions for Hermes Agent through Xquik
+
+See [Part 22](./part22-latest-power-moves.md#4-use-plugins-for-integrations-not-one-off-scripts) for plugin-first integration guidance.
+
+---
+
 ## Coding-agent integrations
 
 - [Claude Code](https://docs.claude.com/en/docs/claude-code) — `claude -p` + ACP; best unattended PR lane with Sonnet 5 / Opus 4.7


### PR DESCRIPTION
## Summary

Re-applies the useful content from #10 on top of current `main` without carrying the stale PR branch's old `ECOSYSTEM.md` snapshot, which would have reverted newer MCP and coding-agent entries.

## Changes

- Adds a **Native Hermes plugins** section to `ECOSYSTEM.md`.
- Adds `hermes-tweet` as a public Hermes Agent plugin for X/Twitter search, reads, and gated account actions through Xquik.
- Adds the original narrow `discord.gg` ignore pattern to `.github/markdown-link-check.json`.
- Adds a current changelog entry.

## Verification

- `git diff --check` clean.
- Confirmed `https://github.com/Xquik-dev/hermes-tweet` returns 200 and `gh repo view Xquik-dev/hermes-tweet` reports it as active / not archived.

Supersedes #10.

Co-authored-by: kriptoburak <kriptoburak@users.noreply.github.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/hermes-optimization-guide/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->