### PR TITLE
docs: fix two code example accuracy issues

### DIFF
--- a/part11-gateway-recovery.md
+++ b/part11-gateway-recovery.md
@@ -187,7 +187,7 @@ if ! curl -s http://localhost:8642/health > /dev/null 2>&1; then
 fi
 
 # Disk space OK?
-USAGE=$(df -h ~/.hermes | awk 'NR==2 {print $5}' | tr -d '%')
+USAGE=$(df -Ph ~/.hermes | awk 'NR==2 {print $5}' | tr -d '%')
 if [ "$USAGE" -gt 90 ]; then
     echo "WARNING: Disk usage at ${USAGE}%"
     exit 1

--- a/part6-context-compression.md
+++ b/part6-context-compression.md
@@ -47,7 +47,7 @@ try:
     compressed_context = summary
 except Exception as e:
     logger.warning(f"Context compression failed: {e}, preserving original context")
-    return original_context  # Don't compress, don't lose data
+    compressed_context = messages_to_compress  # Don't compress, don't lose data
 ```
 
 **The rule:** If compression can't succeed, keep the uncompressed context. A slower response is better than a wrong one.


### PR DESCRIPTION
## Summary

Re-applies the valid parts of #4 on top of current main:

- `part6-context-compression.md`: the fallback branch in the compression example now assigns `compressed_context = messages_to_compress` instead of returning undefined `original_context`, matching the surrounding assignment style.
- `part11-gateway-recovery.md`: the gateway health-check script now uses `df -Ph` so `awk 'NR==2'` is stable even when long device names would make `df -h` wrap lines.

## Not included from #4

The `part7-memory-system.md` wording change is intentionally not applied. Current Hermes source (`/home/terp/.hermes/hermes-agent/tools/session_search_tool.py`) explicitly documents that `session_search` has no LLM calls and no summary LLM path, so the existing no-API-call wording remains accurate for the current codebase.

## Verification

- `git diff --check` clean.
- Verified against local Hermes v0.14.0 source for the part7 decision.

Supersedes #4.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/hermes-optimization-guide/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->