### PR TITLE
docs: refresh LightRAG model setup examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Dated list of meaningful guide updates. Roughly [Keep a Changelog](https://keepachangelog.com) flavored.
 
+## 2026-05-27 — LightRAG model setup refresh
+
+### Changed
+- Updated the LightRAG setup examples in `part3-lightrag-setup.md` and the
+  combined `README.md` to use current model endpoints: Kimi K2.6 via the
+  international Moonshot API (`https://api.moonshot.ai/v1`) for quality,
+  Cerebras `gpt-oss-120b` for speed, Fireworks Qwen3-Embedding-8B for
+  embeddings, and local Ollama as the free/private option. This replaces the
+  stale PR #1 examples that referenced `kimi-2.5`, the China-only
+  `api.moonshot.cn` endpoint, and deprecated Cerebras `qwen-3-32b`.
+
 ## 2026-05-27 — Ecosystem Directory Update
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -787,8 +787,8 @@ LightRAG does vector DB + knowledge graph **in parallel** during ingestion. One 
 ### Prerequisites
 
 - Python 3.11+
-- An LLM API key (for entity extraction during ingestion — OpenAI, Anthropic, or any OpenAI-compatible provider)
-- An embedding API key (Fireworks recommended for high-quality 4096-dim embeddings, or use local Ollama)
+- An LLM API key for entity extraction during ingestion — **Kimi K2.6** (quality), **Cerebras GPT OSS 120B** (speed), or any OpenAI-compatible provider
+- An embedding API key — **Fireworks + Qwen3-Embedding-8B** for high-quality 4096-dim embeddings, or local **Ollama + nomic-embed-text** for free
 
 ### Install LightRAG
 
@@ -809,23 +809,53 @@ pip install -e ".[api]"
 
 Create `~/.hermes/lightrag/.env`:
 
+**Option A — Kimi K2.6 + Fireworks (quality default):**
+
 ```bash
 # LLM for entity extraction (during ingestion)
 LLM_BINDING=openai
-LLM_MODEL=kimi-2.5                    # What we actually use — great quality/cost ratio
-LLM_BINDING_API_KEY=<your-api-key>
+LLM_MODEL=kimi-k2.6
+LLM_BINDING_HOST=https://api.moonshot.ai/v1
+LLM_BINDING_API_KEY=<your-moonshot-api-key>
 
 # Embedding model (for vector storage)
 EMBEDDING_BINDING=fireworks
 EMBEDDING_MODEL=accounts/fireworks/models/qwen3-embedding-8b
 EMBEDDING_API_KEY=<your-fireworks-api-key>
+```
 
-# Or use local Ollama (free, no API key needed):
-# EMBEDDING_BINDING=ollama
-# EMBEDDING_MODEL=nomic-embed-text
+**Option B — Cerebras GPT OSS 120B + Fireworks (speed default):**
+
+```bash
+# LLM for entity extraction (during ingestion)
+LLM_BINDING=openai
+LLM_MODEL=gpt-oss-120b
+LLM_BINDING_HOST=https://api.cerebras.ai/v1
+LLM_BINDING_API_KEY=<your-cerebras-api-key>
+
+# Embedding model (for vector storage)
+EMBEDDING_BINDING=fireworks
+EMBEDDING_MODEL=accounts/fireworks/models/qwen3-embedding-8b
+EMBEDDING_API_KEY=<your-fireworks-api-key>
+```
+
+**Option C — local Ollama (free, quality varies):**
+
+```bash
+# LLM for entity extraction
+LLM_BINDING=ollama
+LLM_MODEL=qwen3:32b
+LLM_BINDING_HOST=http://localhost:11434
+
+# Embedding model
+EMBEDDING_BINDING=ollama
+EMBEDDING_BINDING_HOST=http://localhost:11434
+EMBEDDING_MODEL=nomic-embed-text
 ```
 
 > **Security tip:** Set restrictive permissions on this file: `chmod 600 ~/.hermes/lightrag/.env`
+
+> **Where to get API keys:** Kimi/Moonshot uses [platform.kimi.ai](https://platform.kimi.ai) and the international base URL `https://api.moonshot.ai/v1`; Cerebras uses [cloud.cerebras.ai](https://cloud.cerebras.ai); Fireworks uses [fireworks.ai](https://fireworks.ai).
 
 ### Entity Extraction Model — What to Use
 
@@ -833,13 +863,11 @@ This is the LLM that reads your documents and pulls out entities and relationshi
 
 | Model | Speed | Quality | Cost | Recommendation |
 |-------|-------|---------|------|----------------|
-| **Kimi 2.5** | Fast | Excellent | Cheap | **What we use.** Great balance of quality, speed, and cost for entity extraction |
-| **Cerebras + Qwen 3** | Blazing fast | Very good | Very cheap | **Fastest option in the world.** Cerebras inference at 2000+ tok/s makes bulk ingestion fly |
-| Gemini 3.1 Flash | Fast | Good | Cheap | Solid fallback, huge context |
-| Claude Sonnet 4 | Medium | Excellent | Mid-range | Overkill for ingestion but works great |
-| **Ollama local** | Depends on GPU | Unpredictable | Free | Untested for this use case — might mess up entity extraction quality. Use at your own risk |
-
-> **Our recommendation:** Kimi 2.5 for quality, Cerebras + Qwen 3 if you're ingesting a lot of documents and speed matters. Both are cheap and reliable. We haven't tested local Ollama for entity extraction — it's free but the extraction quality is unverified and you might get a messy graph.
+| **Kimi K2.6** | Fast | Excellent | Cheap | Best quality/cost default for entity extraction via Moonshot's OpenAI-compatible API |
+| **Cerebras GPT OSS 120B** | Blazing fast | Very good | Very cheap | Fastest current Cerebras production default; use when bulk ingestion speed matters most |
+| Gemini 3.1 Flash | Fast | Good | Cheap | Solid fallback with huge context |
+| Claude Sonnet 5 | Medium | Excellent | Mid/high | Overkill for ingestion but useful for very messy documents |
+| **Ollama local** | Depends on GPU | Unpredictable | Free | Viable for private/local ingestion; validate graph quality before trusting it |
 
 > **Embedding quality matters.** If you have a GPU with 8GB+ VRAM, run `nomic-embed-text` locally via Ollama for free. If you want the best quality, use Fireworks' Qwen3-Embedding-8B (4096 dimensions) — the search accuracy difference is dramatic.
 
@@ -1148,7 +1176,7 @@ cd ~/.hermes/lightrag/LightRAG && lightrag-server --port 9623
 ### Slow ingestion
 
 Entity extraction is LLM-bound. Speed it up:
-- Use a faster model for ingestion (Cerebras + Qwen 3 is the fastest option, or Kimi 2.5)
+- Use a faster model for ingestion (Cerebras GPT OSS 120B for speed, Kimi K2.6 for quality, Gemini 3.1 Flash as a cheap fallback)
 - Process documents in parallel batches
 - Use a local model if you have GPU capacity
 

--- a/part3-lightrag-setup.md
+++ b/part3-lightrag-setup.md
@@ -48,8 +48,8 @@ LightRAG does vector DB + knowledge graph **in parallel** during ingestion. One 
 ### Prerequisites
 
 - Python 3.11+
-- An LLM API key (for entity extraction during ingestion — OpenAI, Anthropic, or any OpenAI-compatible provider)
-- An embedding API key (Fireworks recommended for high-quality 4096-dim embeddings, or use local Ollama)
+- An LLM API key for entity extraction during ingestion — **Kimi K2.6** (quality), **Cerebras GPT OSS 120B** (speed), or any OpenAI-compatible provider
+- An embedding API key — **Fireworks + Qwen3-Embedding-8B** for high-quality 4096-dim embeddings, or local **Ollama + nomic-embed-text** for free
 
 ### Install LightRAG
 
@@ -70,25 +70,65 @@ pip install -e ".[api]"
 
 Create `~/.hermes/lightrag/.env`:
 
+**Option A — Kimi K2.6 + Fireworks (quality default):**
+
 ```bash
 # LLM for entity extraction (during ingestion)
 LLM_BINDING=openai
-LLM_MODEL=google/gemini-3.1-flash
-LLM_BINDING_API_KEY=<your-gemini-api-key-or-oauth-token>
+LLM_MODEL=kimi-k2.6
+LLM_BINDING_HOST=https://api.moonshot.ai/v1
+LLM_BINDING_API_KEY=<your-moonshot-api-key>
 
 # Embedding model (for vector storage)
 EMBEDDING_BINDING=fireworks
 EMBEDDING_MODEL=accounts/fireworks/models/qwen3-embedding-8b
 EMBEDDING_API_KEY=<your-fireworks-api-key>
+```
 
-# Or use local Ollama (free, no API key needed):
-# EMBEDDING_BINDING=ollama
-# EMBEDDING_MODEL=nomic-embed-text
+**Option B — Cerebras GPT OSS 120B + Fireworks (speed default):**
+
+```bash
+# LLM for entity extraction (during ingestion)
+LLM_BINDING=openai
+LLM_MODEL=gpt-oss-120b
+LLM_BINDING_HOST=https://api.cerebras.ai/v1
+LLM_BINDING_API_KEY=<your-cerebras-api-key>
+
+# Embedding model (for vector storage)
+EMBEDDING_BINDING=fireworks
+EMBEDDING_MODEL=accounts/fireworks/models/qwen3-embedding-8b
+EMBEDDING_API_KEY=<your-fireworks-api-key>
+```
+
+**Option C — local Ollama (free, quality varies):**
+
+```bash
+# LLM for entity extraction
+LLM_BINDING=ollama
+LLM_MODEL=qwen3:32b
+LLM_BINDING_HOST=http://localhost:11434
+
+# Embedding model
+EMBEDDING_BINDING=ollama
+EMBEDDING_BINDING_HOST=http://localhost:11434
+EMBEDDING_MODEL=nomic-embed-text
 ```
 
 > **Security tip:** Set restrictive permissions on this file: `chmod 600 ~/.hermes/lightrag/.env`
 
-> **Tip:** Use a cheap GPT-5.5-mini/Gemini Flash-class model for entity extraction. It doesn't need to be your smartest model — it just needs to reliably identify entities and relationships. Cheaper models save money on ingestion.
+> **Where to get API keys:** Kimi/Moonshot uses [platform.kimi.ai](https://platform.kimi.ai) and the international base URL `https://api.moonshot.ai/v1`; Cerebras uses [cloud.cerebras.ai](https://cloud.cerebras.ai); Fireworks uses [fireworks.ai](https://fireworks.ai).
+
+### Entity Extraction Model — What to Use
+
+This is the LLM that reads your documents and pulls out entities and relationships during ingestion. Quality here directly determines how good your knowledge graph is.
+
+| Model | Speed | Quality | Cost | Recommendation |
+|-------|-------|---------|------|----------------|
+| **Kimi K2.6** | Fast | Excellent | Cheap | Best quality/cost default for entity extraction via Moonshot's OpenAI-compatible API |
+| **Cerebras GPT OSS 120B** | Blazing fast | Very good | Very cheap | Fastest current Cerebras production default; use when bulk ingestion speed matters most |
+| Gemini 3.1 Flash | Fast | Good | Cheap | Solid fallback with huge context |
+| Claude Sonnet 5 | Medium | Excellent | Mid/high | Overkill for ingestion but useful for very messy documents |
+| **Ollama local** | Depends on GPU | Unpredictable | Free | Viable for private/local ingestion; validate graph quality before trusting it |
 
 > **Embedding quality matters.** If you have a GPU with 8GB+ VRAM, run `nomic-embed-text` locally via Ollama for free. If you want the best quality, use Fireworks' Qwen3-Embedding-8B (4096 dimensions) — the search accuracy difference is dramatic.
 
@@ -391,7 +431,7 @@ cd ~/.hermes/lightrag/LightRAG && lightrag-server --port 9623
 ### Slow ingestion
 
 Entity extraction is LLM-bound. Speed it up:
-- Use a faster model for ingestion (Gemini 3.1 Flash, Kimi K2.6, or Claude Haiku)
+- Use a faster model for ingestion (Cerebras GPT OSS 120B for speed, Kimi K2.6 for quality, Gemini 3.1 Flash as a cheap fallback)
 - Process documents in parallel batches
 - Use a local model if you have GPU capacity
 


### PR DESCRIPTION
## Summary

Replaces #1 with a current-main-safe LightRAG setup refresh. The original PR had the right idea (show multiple LightRAG model options), but the exact examples are now stale:

- `kimi-2.5` is no longer the recommended current Kimi slug; Kimi's public docs now show `kimi-k2.6`.
- `https://api.moonshot.cn/v1` is the China-region endpoint; the international Kimi API docs use `https://api.moonshot.ai/v1`.
- Cerebras `qwen-3-32b` is deprecated; the current production speed default is `gpt-oss-120b`.

## Changes

- Updates both `part3-lightrag-setup.md` and the combined `README.md`.
- Adds three LightRAG `.env` options:
  - Kimi K2.6 + Fireworks Qwen3-Embedding-8B (quality default)
  - Cerebras GPT OSS 120B + Fireworks Qwen3-Embedding-8B (speed default)
  - local Ollama LLM + local `nomic-embed-text` embeddings (free/private)
- Keeps LightRAG's real `LLM_BINDING_HOST` / `EMBEDDING_BINDING_HOST` env vars.
- Updates the entity-extraction model table and slow-ingestion recommendation.
- Adds a changelog entry.

## Verification

- `git diff --check` clean.
- LightRAG docs confirm `LLM_BINDING_HOST` is the correct env var for OpenAI-compatible and Ollama endpoints.
- Kimi API docs confirm `https://api.moonshot.ai/v1` and `kimi-k2.6`.
- Cerebras docs mark `qwen-3-32b` deprecated and list `gpt-oss-120b` as a current production model.

Supersedes #1.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/hermes-optimization-guide/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->