### PR TITLE
fix: update Hermes config schema examples

### DIFF
--- a/docs/reference-architectures/homelab.md
+++ b/docs/reference-architectures/homelab.md
@@ -73,37 +73,33 @@ ollama pull qwen2.5-coder:32b
 Start from [`templates/config/production.yaml`](../../templates/config/production.yaml), then:
 
 ```yaml
-models:
-  default: ollama/llama3.1:70b-instruct-q4_K_M
-  providers:
-    ollama:
-      base_url: http://gpu-box.tailnet-xxx.ts.net:11434
-    anthropic:
-      api_key: "${ANTHROPIC_API_KEY}"        # fallback for hard queries
+_config_version: 28
 
-  routing:
-    - when: task == "reasoning"
-      use: anthropic/claude-sonnet-5
-    - when: task == "coding" && complexity == "high"
-      use: anthropic/claude-sonnet-5
+model:
+  provider: ollama
+  default: llama3.1:70b-instruct-q4_K_M
+  base_url: http://gpu-box.tailnet-xxx.ts.net:11434
 
-gateways:
-  cli:
-    enabled: true
-  telegram:
-    enabled: true
-    bots:
-      admin:
-        token: "${TELEGRAM_ADMIN_BOT_TOKEN}"
-        allowed_user_ids:
-          - ${TELEGRAM_OWNER_ID}
+fallback_providers:
+  - provider: anthropic
+    model: anthropic/claude-sonnet-5
+
+auxiliary:
+  compression:
+    provider: ollama
+    model: qwen2.5-coder:32b
+    base_url: http://gpu-box.tailnet-xxx.ts.net:11434
+
+telegram:
+  # Token/user allowlists live in ~/.hermes/.env or are written by:
+  #   hermes gateway setup
+  allowed_chats: "${TELEGRAM_ALLOWED_CHATS}"
+  reactions: true
 
 memory:
-  backend: lightrag
-  lightrag:
-    working_dir: /var/lib/hermes/lightrag
-    llm_model: ollama/qwen2.5-coder:32b         # local extraction
-    embedding_model: openai/text-embedding-3-small  # or local (bge-m3)
+  memory_enabled: true
+  user_profile_enabled: true
+  provider: ""  # built-in memory; keep LightRAG as an external MCP/skill integration
 ```
 
 ### 5. Langfuse self-host (observability inside the LAN)
@@ -115,7 +111,7 @@ cp templates/compose/.env.langfuse.example /opt/.env.langfuse
 docker compose -f /opt/langfuse-stack.yml --env-file /opt/.env.langfuse up -d
 ```
 
-Point Hermes `telemetry.langfuse.host` at `http://127.0.0.1:3000`.
+Point the observability plugin at Langfuse with `HERMES_LANGFUSE_BASE_URL=http://127.0.0.1:3000` plus the matching Langfuse public/secret keys in `~/.hermes/.env`.
 
 ### 6. Skills
 
@@ -123,7 +119,7 @@ Point Hermes `telemetry.langfuse.host` at `http://127.0.0.1:3000`.
 for skill in /opt/hermes-optimization-guide/skills/*/*/; do
   ln -sfn "$skill" "/home/hermes/.hermes/skills/$(basename $skill)"
 done
-hermes /reload
+# Restart Hermes, start a new session, or run /reload-skills inside an active chat.
 ```
 
 ## Honest tradeoffs

--- a/docs/reference-architectures/road-warrior.md
+++ b/docs/reference-architectures/road-warrior.md
@@ -51,47 +51,32 @@ Then customize:
 
 ```yaml
 # /home/hermes/.hermes/config.yaml
-version: 1
+_config_version: 28
 
-models:
+model:
+  provider: gemini
   default: google/gemini-3.1-flash          # Cheap + fast for "plan the work" phase
-  providers:
-    google:
-      api_key: "${GOOGLE_API_KEY}"
-    anthropic:
-      api_key: "${ANTHROPIC_API_KEY}"       # Used by sandboxed Claude Code
 
-gateways:
-  cli: { enabled: true }
-  telegram:
-    enabled: true
-    bots:
-      admin:
-        token: "${TELEGRAM_ADMIN_BOT_TOKEN}"
-        allowed_user_ids:
-          - ${TELEGRAM_OWNER_ID}
+fallback_providers:
+  - provider: anthropic
+    model: anthropic/claude-sonnet-5        # Premium fallback for hard coding turns
 
-# The money section
-remote_sandbox:
-  default_backend: modal          # Or daytona / fly / e2b / ssh
-  backends:
-    modal:
-      token_id: "${MODAL_TOKEN_ID}"
-      token_secret: "${MODAL_TOKEN_SECRET}"
-      image: "python:3.12-slim"
-      timeout_idle: 600           # 10m idle → auto-shutdown
-    ssh:                          # your home beast, if any
-      host: "beast.tailnet-xxx.ts.net"
-      user: "hermes"
-      identity_file: "~/.ssh/id_ed25519"
+telegram:
+  # Token/user allowlists live in ~/.hermes/.env or are written by:
+  #   hermes gateway setup
+  allowed_chats: "${TELEGRAM_ALLOWED_CHATS}"
+  reactions: true
 
-# Hermes loads skills from here; these let you orchestrate from Telegram
+# Pick one current terminal backend for remote execution.
+terminal:
+  backend: modal                            # local | docker | ssh | modal | daytona | singularity
+  modal_image: python:3.12-slim
+  timeout: 600
+
+# Hermes loads shared guide skills from here; install/sync them first.
 skills:
-  allowlist:
-    - pr-review
-    - release-notes
-    - cost-report
-    - remote-run          # triggers a sandbox
+  external_dirs:
+    - /opt/hermes-optimization-guide/skills
 ```
 
 ## The workflow
@@ -125,8 +110,9 @@ for s in /opt/hermes-optimization-guide/skills/*/*/; do
 done
 
 # Write a tiny remote-run skill (paste into ~/.hermes/skills/remote-run/SKILL.md)
-# that wraps `hermes sandbox run --repo acme/app -- claude -p "$@"`
-hermes /reload
+# that switches terminal.backend to modal/daytona/ssh for the run, invokes the
+# coding agent, then restores the driver defaults.
+# Restart Hermes, start a new session, or run /reload-skills inside an active chat.
 ```
 
 ## Safety rails

--- a/docs/wizard/index.html
+++ b/docs/wizard/index.html
@@ -66,7 +66,7 @@
       <p class="hint">Picks the starting template.</p>
       <label><input type="radio" name="persona" value="minimum" onchange="applyPersona(this.value)" checked> Just me, CLI only (simplest)</label>
       <label><input type="radio" name="persona" value="telegram-bot" onchange="applyPersona(this.value)"> Me + a Telegram bot</label>
-      <label><input type="radio" name="persona" value="production" onchange="applyPersona(this.value)"> Production deployment (multi-gateway, multi-provider, memory, MCP, alerts)</label>
+      <label><input type="radio" name="persona" value="production" onchange="applyPersona(this.value)"> Production deployment (multi-platform, multi-provider, memory, MCP, alerts)</label>
       <label><input type="radio" name="persona" value="cost-optimized" onchange="applyPersona(this.value)"> Cost-optimized (&lt;$5/mo personal daily-driver)</label>
       <label><input type="radio" name="persona" value="security-hardened" onchange="applyPersona(this.value)"> Security-hardened (public-facing, untrusted input)</label>
     </fieldset>
@@ -88,14 +88,14 @@
 
     <fieldset class="grid2">
       <div>
-        <legend>3. Memory backend</legend>
-        <label><input type="radio" name="memory" value="vector" checked> Vector DB (qdrant, fast, simple)</label>
-        <label><input type="radio" name="memory" value="lightrag"> LightRAG (knowledge graph + vector; Part 3)</label>
-        <label><input type="radio" name="memory" value="mem0"> mem0 cloud (cross-device)</label>
+        <legend>3. Memory</legend>
+        <label><input type="radio" name="memory" value="builtin" checked> Built-in Hermes memory (simple, local)</label>
+        <label><input type="radio" name="memory" value="mem0"> mem0 external provider (cross-device)</label>
+        <label><input type="radio" name="memory" value="lightrag"> LightRAG as external MCP/skill (comments only)</label>
         <label><input type="radio" name="memory" value="none"> None</label>
       </div>
       <div>
-        <legend>4. Gateways</legend>
+        <legend>4. Gateway platforms</legend>
         <label><input type="checkbox" name="gw_cli" checked> CLI</label>
         <label><input type="checkbox" name="gw_telegram"> Telegram</label>
         <label><input type="checkbox" name="gw_discord"> Discord</label>
@@ -183,14 +183,13 @@ function select(name) {
   return el ? el.value : null;
 }
 
-/* Persona presets — each object mirrors the shape of the corresponding
-   templates/config/<persona>.yaml. When the user picks a persona, the
-   rest of the form is pre-filled so Question 1 actually drives output. */
+/* Persona presets — each object mirrors the current Hermes config
+   surfaces used by templates/config/*.yaml. */
 const PERSONA_PRESETS = {
   'minimum': {
     default_model: 'anthropic/claude-sonnet-5',
-    memory: 'vector',
-    gateways: { cli: true, telegram: false, discord: false, slack: false, email: false, webhook: false },
+    memory: 'builtin',
+    platforms: { cli: true, telegram: false, discord: false, slack: false, email: false, webhook: false },
     mcps:     { github: false, postgres: false, cloudflare: false, linear: false, filesystem: false, mem0: false },
     approval: 'moderate',
     obs: 'none',
@@ -198,8 +197,8 @@ const PERSONA_PRESETS = {
   },
   'telegram-bot': {
     default_model: 'anthropic/claude-sonnet-5',
-    memory: 'lightrag',
-    gateways: { cli: true, telegram: true, discord: false, slack: false, email: false, webhook: false },
+    memory: 'builtin',
+    platforms: { cli: true, telegram: true, discord: false, slack: false, email: false, webhook: false },
     mcps:     { github: true, postgres: false, cloudflare: false, linear: false, filesystem: false, mem0: false },
     approval: 'moderate',
     obs: 'none',
@@ -207,8 +206,8 @@ const PERSONA_PRESETS = {
   },
   'production': {
     default_model: 'anthropic/claude-sonnet-5',
-    memory: 'lightrag',
-    gateways: { cli: true, telegram: true, discord: true, slack: true, email: true, webhook: true },
+    memory: 'mem0',
+    platforms: { cli: true, telegram: true, discord: true, slack: true, email: true, webhook: true },
     mcps:     { github: true, postgres: true, cloudflare: true, linear: true, filesystem: true, mem0: false },
     approval: 'strict',
     obs: 'langfuse',
@@ -216,8 +215,8 @@ const PERSONA_PRESETS = {
   },
   'cost-optimized': {
     default_model: 'google/gemini-3.1-flash',
-    memory: 'lightrag',
-    gateways: { cli: true, telegram: true, discord: false, slack: false, email: false, webhook: false },
+    memory: 'builtin',
+    platforms: { cli: true, telegram: true, discord: false, slack: false, email: false, webhook: false },
     mcps:     { github: true, postgres: false, cloudflare: false, linear: false, filesystem: true, mem0: false },
     approval: 'moderate',
     obs: 'none',
@@ -225,8 +224,8 @@ const PERSONA_PRESETS = {
   },
   'security-hardened': {
     default_model: 'anthropic/claude-sonnet-5',
-    memory: 'vector',
-    gateways: { cli: true, telegram: true, discord: false, slack: false, email: false, webhook: true },
+    memory: 'builtin',
+    platforms: { cli: true, telegram: true, discord: false, slack: false, email: false, webhook: true },
     mcps:     { github: true, postgres: false, cloudflare: false, linear: false, filesystem: false, mem0: false },
     approval: 'strict',
     obs: 'langfuse',
@@ -254,21 +253,66 @@ function applyPersona(persona) {
   setRadio('memory', p.memory);
   setRadio('approval', p.approval);
   setRadio('obs', p.obs);
-  Object.entries(p.gateways).forEach(([k, v]) => setCheckbox('gw_' + k, v));
+  Object.entries(p.platforms).forEach(([k, v]) => setCheckbox('gw_' + k, v));
   Object.entries(p.mcps).forEach(([k, v]) => setCheckbox('mcp_' + k, v));
   Object.entries(p.crons).forEach(([k, v]) => setCheckbox('cron_' + k, v));
   generate();
   setStatus(`Loaded "${persona}" preset — tweak any field, then Generate.`);
 }
 
+function providerForModel(model) {
+  if (model.startsWith('anthropic/')) return 'anthropic';
+  if (model.startsWith('google/')) return 'gemini';
+  if (model.startsWith('openai/')) return 'openai-codex';
+  if (model.startsWith('xai/')) return 'xai';
+  if (model.startsWith('moonshot/')) return 'kimi-coding';
+  if (model.startsWith('zai/')) return 'zai';
+  return 'openrouter';
+}
+
+function credentialHint(provider) {
+  const hints = {
+    anthropic: 'ANTHROPIC_API_KEY',
+    gemini: 'GEMINI_API_KEY or GOOGLE_API_KEY, or Gemini OAuth via hermes auth',
+    'openai-codex': 'hermes auth add openai-codex',
+    xai: 'XAI_API_KEY or xAI OAuth via hermes auth',
+    'kimi-coding': 'KIMI_API_KEY or KIMI_CODING_API_KEY',
+    zai: 'ZAI_API_KEY',
+    openrouter: 'OPENROUTER_API_KEY',
+  };
+  return hints[provider] || 'provider-specific key';
+}
+
+function emitAuxiliary(lines, approval) {
+  lines.push(`auxiliary:`);
+  lines.push(`  compression:`);
+  lines.push(`    provider: gemini`);
+  lines.push(`    model: google/gemini-3.1-flash`);
+  lines.push(`    timeout: 120`);
+  lines.push(`    extra_body: {}`);
+  if (approval !== 'relaxed') {
+    lines.push(`  approval:`);
+    lines.push(`    provider: gemini`);
+    lines.push(`    model: google/gemini-3.1-flash`);
+    lines.push(`    timeout: 30`);
+    lines.push(`    extra_body: {}`);
+  }
+}
+
+function emitSamplingDisabled(lines, indent) {
+  lines.push(`${indent}sampling:`);
+  lines.push(`${indent}  enabled: false`);
+}
+
 function generate() {
   const persona = val('persona');
   const model = select('default_model');
+  const provider = providerForModel(model);
   const memory = val('memory');
   const approval = val('approval');
   const obs = val('obs');
 
-  const gateways = {
+  const platforms = {
     cli: on('gw_cli'),
     telegram: on('gw_telegram'),
     discord: on('gw_discord'),
@@ -295,109 +339,100 @@ function generate() {
   lines.push(`# Generated ${new Date().toISOString()} by the Hermes Config Wizard`);
   lines.push(`# https://onlyterp.github.io/hermes-optimization-guide/wizard/`);
   lines.push(`# Persona: ${persona}`);
-  lines.push(`# Pair with ~/.hermes/.env — env vars referenced as $\{VAR\}.`);
+  lines.push(`# Current Hermes config schema: _config_version 28`);
+  lines.push(`# Put secrets in ~/.hermes/.env or use hermes auth/setup wizards.`);
   lines.push(``);
-  lines.push(`version: 1`);
+  lines.push(`_config_version: 28`);
   lines.push(``);
-  lines.push(`models:`);
+  lines.push(`model:`);
+  lines.push(`  provider: ${provider}`);
   lines.push(`  default: ${model}`);
-  lines.push(`  providers:`);
-  const providerKeys = {
-    anthropic: 'ANTHROPIC_API_KEY',
-    google:    'GOOGLE_API_KEY',
-    openai:    'OPENAI_API_KEY',
-    moonshot:  'MOONSHOT_API_KEY',
-    zai:       'ZAI_API_KEY',
-    cerebras:  'CEREBRAS_API_KEY',
-    xai:       'XAI_API_KEY',
-  };
-  // Providers required by each persona's routing rules (must be superset of
-  // models referenced in routing blocks later in this function).
-  const EXTRA_PROVIDERS = {
-    'cost-optimized': ['anthropic', 'google', 'moonshot', 'cerebras'],
-    'production':     ['anthropic', 'google', 'xai'],
-    'security-hardened': ['anthropic'],
-  };
-  const providersToEmit = new Set([model.split('/')[0]]);
-  (EXTRA_PROVIDERS[persona] || []).forEach(p => providersToEmit.add(p));
-  // LightRAG uses google/gemini-3.1-flash (LLM) + openai/text-embedding-3-small
-  // (embedding) — make sure both providers are configured.
-  if (memory === 'lightrag') { providersToEmit.add('google'); providersToEmit.add('openai'); }
-  // mem0 is a cloud service with its own key; no extra LLM provider needed here.
-  [...providersToEmit].forEach(p => {
-    const envVar = providerKeys[p] || 'API_KEY';
-    lines.push(`    ${p}:`);
-    lines.push(`      api_key: "$\{${envVar}\}"`);
-  });
+  lines.push(``);
+  lines.push(`# Credential hint for the selected provider: ${credentialHint(provider)}`);
   lines.push(``);
 
-  // Gateways
-  lines.push(`gateways:`);
-  if (gateways.cli) lines.push(`  cli:\n    enabled: true`);
-  if (gateways.telegram) {
-    lines.push(`  telegram:`);
-    lines.push(`    enabled: true`);
-    lines.push(`    bots:`);
-    lines.push(`      admin:`);
-    lines.push(`        token: "$\{TELEGRAM_ADMIN_BOT_TOKEN\}"`);
-    lines.push(`        allowed_user_ids:`);
-    lines.push(`          - $\{TELEGRAM_OWNER_ID\}`);
-    lines.push(`        trust_label: high`);
-  }
-  if (gateways.discord) {
-    lines.push(`  discord:`);
-    lines.push(`    enabled: true`);
-    lines.push(`    bot_token: "$\{DISCORD_BOT_TOKEN\}"`);
-    lines.push(`    trust_label: medium`);
-  }
-  if (gateways.slack) {
-    lines.push(`  slack:`);
-    lines.push(`    enabled: true`);
-    lines.push(`    signing_secret: "$\{SLACK_SIGNING_SECRET\}"`);
-    lines.push(`    bot_token: "$\{SLACK_BOT_TOKEN\}"`);
-  }
-  if (gateways.email) {
-    lines.push(`  email:`);
-    lines.push(`    enabled: true`);
-    lines.push(`    imap:`);
-    lines.push(`      host: imap.gmail.com`);
-    lines.push(`      user: "$\{EMAIL_USER\}"`);
-    lines.push(`      password: "$\{EMAIL_APP_PASSWORD\}"`);
-    lines.push(`    smtp:`);
-    lines.push(`      host: smtp.gmail.com`);
-    lines.push(`      user: "$\{EMAIL_USER\}"`);
-    lines.push(`      password: "$\{EMAIL_APP_PASSWORD\}"`);
-    lines.push(`    trust_label: untrusted`);
-  }
-  if (gateways.webhook) {
-    lines.push(`  webhook:`);
-    lines.push(`    enabled: true`);
-    lines.push(`    require_signature: true`);
-    lines.push(`    max_body_bytes: 1048576`);
-  }
-  lines.push(``);
-
-  // Memory
-  if (memory && memory !== 'none') {
-    lines.push(`memory:`);
-    lines.push(`  backend: ${memory}`);
-    if (memory === 'vector') {
-      lines.push(`  vector:`);
-      lines.push(`    driver: qdrant`);
-      lines.push(`    path: ~/.hermes/vector`);
-    } else if (memory === 'lightrag') {
-      lines.push(`  lightrag:`);
-      lines.push(`    working_dir: ~/.hermes/lightrag`);
-      lines.push(`    llm_model: google/gemini-3.1-flash`);
-      lines.push(`    embedding_model: openai/text-embedding-3-small`);
-    } else if (memory === 'mem0') {
-      lines.push(`  mem0:`);
-      lines.push(`    api_key: "$\{MEM0_API_KEY\}"`);
-    }
+  if (persona === 'production') {
+    lines.push(`fallback_providers:`);
+    lines.push(`  - provider: gemini`);
+    lines.push(`    model: google/gemini-3.1-pro`);
+    lines.push(`  - provider: kimi-coding`);
+    lines.push(`    model: moonshot/kimi-k2.6`);
+    lines.push(``);
+  } else if (persona === 'cost-optimized') {
+    lines.push(`fallback_providers:`);
+    lines.push(`  - provider: kimi-coding`);
+    lines.push(`    model: moonshot/kimi-k2.6`);
+    lines.push(`  - provider: openrouter`);
+    lines.push(`    model: google/gemini-3.1-pro`);
     lines.push(``);
   }
 
-  // MCP servers
+  lines.push(`compression:`);
+  lines.push(`  enabled: true`);
+  lines.push(`  threshold: ${persona === 'cost-optimized' ? '0.40' : '0.50'}`);
+  lines.push(`  target_ratio: 0.20`);
+  lines.push(``);
+  emitAuxiliary(lines, approval);
+  lines.push(``);
+
+  // Platform behavior. Tokens/allowlists are configured by hermes gateway setup or env vars.
+  if (platforms.telegram) {
+    lines.push(`telegram:`);
+    lines.push(`  reactions: ${persona === 'security-hardened' ? 'false' : 'true'}`);
+    lines.push(`  allowed_chats: "\${TELEGRAM_ALLOWED_CHATS}"`);
+    lines.push(`  channel_prompts: {}`);
+    lines.push(``);
+  }
+  if (platforms.discord) {
+    lines.push(`discord:`);
+    lines.push(`  require_mention: true`);
+    lines.push(`  allowed_channels: "\${DISCORD_ALLOWED_CHANNELS}"`);
+    lines.push(`  auto_thread: true`);
+    lines.push(`  history_backfill: true`);
+    lines.push(`  reactions: true`);
+    lines.push(`  channel_prompts: {}`);
+    lines.push(``);
+  }
+  if (platforms.slack) {
+    lines.push(`slack:`);
+    lines.push(`  require_mention: true`);
+    lines.push(`  allowed_channels: "\${SLACK_ALLOWED_CHANNELS}"`);
+    lines.push(`  channel_prompts: {}`);
+    lines.push(``);
+  }
+  if (platforms.email) {
+    lines.push(`# Email gateway credentials are env-driven in current Hermes.`);
+    lines.push(`# Run hermes gateway setup and set EMAIL_* / platform-specific env vars there.`);
+    lines.push(``);
+  }
+  if (platforms.webhook) {
+    lines.push(`# Webhook routes are managed with: hermes webhook subscribe <name>`);
+    lines.push(`# Keep WEBHOOK_SECRET and API_SERVER_* values in ~/.hermes/.env.`);
+    lines.push(``);
+  }
+
+  // Memory
+  lines.push(`memory:`);
+  if (memory === 'none') {
+    lines.push(`  memory_enabled: false`);
+    lines.push(`  user_profile_enabled: false`);
+    lines.push(`  provider: ""`);
+  } else if (memory === 'mem0') {
+    lines.push(`  memory_enabled: true`);
+    lines.push(`  user_profile_enabled: true`);
+    lines.push(`  provider: mem0`);
+  } else {
+    lines.push(`  memory_enabled: true`);
+    lines.push(`  user_profile_enabled: true`);
+    lines.push(`  provider: ""`);
+    if (memory === 'lightrag') {
+      lines.push(`# LightRAG is not a built-in memory provider in current Hermes.`);
+      lines.push(`# Use an MCP server or the lightrag-query skill as an external integration.`);
+    }
+  }
+  lines.push(``);
+
+  // MCP servers. mcp_servers is current; use sampling.* and tools.include for filtering.
   const anyMcp = Object.values(mcps).some(Boolean);
   if (anyMcp) {
     lines.push(`mcp_servers:`);
@@ -406,143 +441,123 @@ function generate() {
       lines.push(`    command: npx`);
       lines.push(`    args: [-y, "@modelcontextprotocol/server-github"]`);
       lines.push(`    env:`);
-      lines.push(`      GITHUB_PERSONAL_ACCESS_TOKEN: "$\{GITHUB_PAT\}"`);
-      lines.push(`    trust: trusted`);
-      lines.push(`    allow_sampling: false`);
+      lines.push(`      GITHUB_PERSONAL_ACCESS_TOKEN: "\${GITHUB_PAT}"`);
+      emitSamplingDisabled(lines, '    ');
+      lines.push(`    tools:`);
+      lines.push(`      include:`);
+      lines.push(`        - get_pull_request`);
+      lines.push(`        - list_pull_requests`);
+      lines.push(`        - get_pull_request_diff`);
+      lines.push(`        - add_issue_comment`);
     }
     if (mcps.postgres) {
       lines.push(`  postgres:`);
       lines.push(`    command: npx`);
-      lines.push(`    args: [-y, "@modelcontextprotocol/server-postgres", "$\{DATABASE_URL\}"]`);
-      lines.push(`    trust: trusted`);
-      lines.push(`    allow_sampling: false`);
+      lines.push(`    args: [-y, "@modelcontextprotocol/server-postgres", "\${POSTGRES_URL}"]`);
+      emitSamplingDisabled(lines, '    ');
     }
     if (mcps.cloudflare) {
       lines.push(`  cloudflare:`);
       lines.push(`    command: npx`);
       lines.push(`    args: [-y, "@cloudflare/mcp-server-cloudflare"]`);
       lines.push(`    env:`);
-      lines.push(`      CLOUDFLARE_API_TOKEN: "$\{CLOUDFLARE_API_TOKEN\}"`);
-      lines.push(`    trust: trusted`);
+      lines.push(`      CLOUDFLARE_API_TOKEN: "\${CLOUDFLARE_API_TOKEN}"`);
+      emitSamplingDisabled(lines, '    ');
     }
     if (mcps.linear) {
       lines.push(`  linear:`);
       lines.push(`    url: https://mcp.linear.app/mcp`);
-      lines.push(`    # OAuth is completed by the MCP client on first connection.`);
-      lines.push(`    trust: trusted`);
-      lines.push(`    allow_sampling: false`);
+      lines.push(`    auth: oauth`);
+      emitSamplingDisabled(lines, '    ');
     }
     if (mcps.filesystem) {
       lines.push(`  filesystem:`);
       lines.push(`    command: npx`);
-      lines.push(`    args: [-y, "@modelcontextprotocol/server-filesystem", "/home/hermes/scratch"]`);
-      lines.push(`    trust: trusted`);
+      lines.push(`    args: [-y, "@modelcontextprotocol/server-filesystem", "\${HOME}/hermes-scratch"]`);
+      emitSamplingDisabled(lines, '    ');
     }
     if (mcps.mem0) {
       lines.push(`  mem0:`);
       lines.push(`    command: npx`);
       lines.push(`    args: [-y, "@mem0ai/mcp-server-mem0"]`);
       lines.push(`    env:`);
-      lines.push(`      MEM0_API_KEY: "$\{MEM0_API_KEY\}"`);
+      lines.push(`      MEM0_API_KEY: "\${MEM0_API_KEY}"`);
+      emitSamplingDisabled(lines, '    ');
     }
     lines.push(``);
   }
 
-  // Approval
-  lines.push(`security:`);
-  lines.push(`  approval:`);
+  // Approval and security
+  lines.push(`approvals:`);
   if (approval === 'strict') {
-    lines.push(`    auto_approve_read: false`);
-    lines.push(`    require_approval:`);
-    lines.push(`      - { tool: "*", actions: [exec, write, send, create, update, delete, post] }`);
-    lines.push(`    approval_timeout: 300`);
+    lines.push(`  mode: manual`);
+    lines.push(`  timeout: 300`);
   } else if (approval === 'moderate') {
-    lines.push(`    auto_approve_read: true`);
-    lines.push(`    require_approval:`);
-    lines.push(`      - { tool: github, actions: [create_pr, merge_pr, delete_branch] }`);
-    lines.push(`      - { tool: terminal, actions: [exec] }`);
-    lines.push(`      - { tool: email, actions: [send] }`);
-    lines.push(`      - { tool: any_mcp, sampling: true }`);
+    lines.push(`  mode: smart`);
+    lines.push(`  timeout: 60`);
   } else {
-    lines.push(`    auto_approve_read: true`);
-    lines.push(`    require_approval: []`);
+    lines.push(`  mode: off`);
+    lines.push(`  timeout: 60`);
   }
-  lines.push(`    denylist:`);
-  lines.push(`      - 'rm\\s+-rf\\s+/'`);
-  lines.push(`      - 'curl\\s+.+\\|\\s*(sh|bash)'`);
-  lines.push(`      - '169\\.254\\.169\\.254'`);
-  lines.push(`      - 'cat\\s+~?/?\\.?ssh/'`);
+  lines.push(`  cron_mode: deny`);
+  lines.push(`  mcp_reload_confirm: true`);
+  lines.push(`  destructive_slash_confirm: true`);
+  lines.push(``);
 
-  // Persona-specific security blocks
-  if (persona === 'security-hardened') {
-    lines.push(`  mcp:`);
-    lines.push(`    default_trust: untrusted`);
-    lines.push(`    require_allowlist: true`);
-    lines.push(`    allow_sampling: false`);
-  } else if (anyMcp) {
-    lines.push(`  mcp:`);
-    lines.push(`    default_trust: trusted`);
-    lines.push(`    allow_sampling: false`);
-  }
-
+  lines.push(`security:`);
+  lines.push(`  redact_secrets: true`);
+  lines.push(`  tirith_enabled: true`);
+  lines.push(`  allow_private_urls: false`);
   if (persona === 'security-hardened' || persona === 'production') {
-    lines.push(`  webhook:`);
-    lines.push(`    max_body_bytes: 1048576`);
-    lines.push(`    require_signature: true`);
-    lines.push(`  redaction:`);
-    lines.push(`    memory_write: true`);
-    lines.push(`    log: true`);
-    lines.push(``);
-    lines.push(`profiles:`);
-    lines.push(`  quarantine:`);
-    lines.push(`    # Low-trust gateways route here: no memory writes, no MCP, read-only tools`);
-    lines.push(`    allow_memory_write: false`);
-    lines.push(`    allow_send: false`);
-    lines.push(`    mcp_servers: []`);
-    lines.push(`    toolsets: [classify]`);
+    lines.push(`  website_blocklist:`);
+    lines.push(`    enabled: true`);
+    lines.push(`    domains: []`);
+    lines.push(`    shared_files: []`);
   }
   lines.push(``);
 
-  // Cost-routing rules for cost-optimized persona
-  if (persona === 'cost-optimized') {
-    lines.push(`routing:`);
-    lines.push(`  rules:`);
-    lines.push(`    - { when: "task.type == 'classify'",       use: "cerebras/qwen-3-32b" }`);
-    lines.push(`    - { when: "context.tokens > 200000",        use: "google/gemini-3.1-pro" }`);
-    lines.push(`    - { when: "task.type == 'code'",            use: "moonshot/kimi-k2.6" }`);
-    lines.push(`    - { when: "task.explicit_opt_in == 'sonnet'", use: "anthropic/claude-sonnet-5" }`);
-    lines.push(`    - { else: true,                              use: "google/gemini-3.1-flash" }`);
+  if (persona === 'security-hardened' || persona === 'production') {
+    lines.push(`privacy:`);
+    lines.push(`  redact_pii: true`);
+    lines.push(``);
+    lines.push(`gateway:`);
+    lines.push(`  strict: true`);
+    lines.push(`  trust_recent_files: false`);
+    lines.push(`  trust_recent_files_seconds: 600`);
     lines.push(``);
   }
 
-  // Telemetry
   if (obs === 'langfuse') {
-    lines.push(`telemetry:`);
-    lines.push(`  level: info`);
-    lines.push(`  exporters:`);
-    lines.push(`    langfuse:`);
-    lines.push(`      public_key: "$\{LANGFUSE_PUBLIC_KEY\}"`);
-    lines.push(`      secret_key: "$\{LANGFUSE_SECRET_KEY\}"`);
-    lines.push(`      host: "$\{LANGFUSE_HOST\}"`);
+    lines.push(`# Langfuse uses observability plugin env vars in current Hermes:`);
+    lines.push(`#   HERMES_LANGFUSE_PUBLIC_KEY=...`);
+    lines.push(`#   HERMES_LANGFUSE_SECRET_KEY=***`);
+    lines.push(`#   HERMES_LANGFUSE_BASE_URL=...`);
+    lines.push(`logging:`);
+    lines.push(`  level: INFO`);
+    lines.push(`  max_size_mb: 10`);
+    lines.push(`  backup_count: 5`);
     lines.push(``);
   } else if (obs === 'helicone') {
-    lines.push(`telemetry:`);
-    lines.push(`  level: info`);
-    lines.push(`  exporters:`);
-    lines.push(`    helicone:`);
-    lines.push(`      api_key: "$\{HELICONE_API_KEY\}"`);
+    lines.push(`# Helicone should be configured as a provider proxy/base_url plus env key,`);
+    lines.push(`# not as a telemetry block in config.yaml.`);
+    lines.push(`logging:`);
+    lines.push(`  level: INFO`);
     lines.push(``);
   }
 
-  // Cron
-  const cronList = [];
-  if (crons.backup) cronList.push(`  - { name: nightly-backup,     schedule: "0 3 * * *", task: "/nightly-backup s3://backups/hermes/ 30" }`);
-  if (crons.deps)   cronList.push(`  - { name: weekly-dep-audit,   schedule: "0 9 * * 1", task: "/weekly-dep-audit severity_floor=high" }`);
-  if (crons.cost)   cronList.push(`  - { name: weekly-cost-report, schedule: "0 9 * * 1", task: "/cost-report window=7d format=markdown" }`);
-  if (crons.mcp)    cronList.push(`  - { name: weekly-mcp-audit,   schedule: "0 10 * * 1", task: "/audit-mcp" }`);
-  if (cronList.length) {
+  // Cron settings plus CLI examples. Job definitions are created by hermes cron create.
+  const cronExamples = [];
+  if (crons.backup) cronExamples.push(`# hermes cron create "0 3 * * *" "Run nightly backup and summarize the result" --skill nightly-backup --deliver telegram`);
+  if (crons.deps)   cronExamples.push(`# hermes cron create "0 9 * * 1" "Run dependency audit and summarize high-severity findings" --skill weekly-dep-audit --deliver telegram`);
+  if (crons.cost)   cronExamples.push(`# hermes cron create "0 9 * * 1" "Generate a weekly cost report" --skill cost-report --deliver telegram`);
+  if (crons.mcp)    cronExamples.push(`# hermes cron create "0 10 * * 1" "Audit configured MCP servers and summarize risk" --skill audit-mcp --deliver telegram`);
+  if (cronExamples.length) {
     lines.push(`cron:`);
-    cronList.forEach(l => lines.push(l));
+    lines.push(`  wrap_response: true`);
+    lines.push(`  max_parallel_jobs: ${persona === 'production' ? 3 : 1}`);
+    lines.push(``);
+    lines.push(`# Create scheduled jobs with the current cron CLI, for example:`);
+    cronExamples.forEach(l => lines.push(l));
     lines.push(``);
   }
 

--- a/part15-new-platforms.md
+++ b/part15-new-platforms.md
@@ -49,17 +49,19 @@ This part covers the v0.9 adapters, the newer v0.12–v0.14 surfaces, and **Andr
 
 Teams is no longer just a proof of the v0.12 plugin architecture. In v0.14 the Graph auth, webhook listener, pipeline runtime, and outbound delivery are wired together, so Teams can be a real enterprise chat surface.
 
-```yaml
-gateways:
-  teams:
-    enabled: true
-    tenant_id: ${MICROSOFT_TENANT_ID}
-    client_id: ${MICROSOFT_TEAMS_CLIENT_ID}
-    client_secret: ${MICROSOFT_TEAMS_CLIENT_SECRET}
-    allowed_teams:
-      - ${MICROSOFT_TEAMS_ADMIN_TEAM}
-    trust_label: medium
+```bash
+hermes gateway setup
 ```
+
+```dotenv
+# ~/.hermes/.env — current Hermes keeps Teams credentials outside config.yaml
+MICROSOFT_TENANT_ID=...
+MICROSOFT_TEAMS_CLIENT_ID=...
+MICROSOFT_TEAMS_CLIENT_SECRET=...
+MICROSOFT_TEAMS_ADMIN_TEAM=...
+```
+
+Keep Teams in a restricted/approved channel until identity mapping is proven.
 
 Keep approvals in a private admin channel, not in the same team/channel where untrusted requests arrive.
 
@@ -67,27 +69,29 @@ Keep approvals in a private admin channel, not in the same team/channel where un
 
 Use LINE when your users are in Japan, Korea, Taiwan, or a consumer/mobile-first workflow. Treat it like Telegram operationally: one admin bot/channel for approvals, strict allowed user IDs, and no write tools in public rooms.
 
-```yaml
-gateways:
-  line:
-    enabled: true
-    channel_access_token: ${LINE_CHANNEL_ACCESS_TOKEN}
-    channel_secret: ${LINE_CHANNEL_SECRET}
-    allowed_user_ids:
-      - ${LINE_ADMIN_USER_ID}
+```bash
+hermes gateway setup
+```
+
+```dotenv
+# ~/.hermes/.env
+LINE_CHANNEL_ACCESS_TOKEN=...
+LINE_CHANNEL_SECRET=...
+LINE_ADMIN_USER_ID=...
 ```
 
 ### SimpleX Chat
 
 SimpleX is the privacy-first choice: no global user IDs, no central identity graph. That is good for privacy and harder for ops. Require pairing, persist local contact labels, and do not use it as the only approval channel until restore/backup is tested.
 
-```yaml
-gateways:
-  simplex:
-    enabled: true
-    profile: simplex-admin
-    require_pairing: true
-    trust_label: medium
+```bash
+hermes gateway setup
+```
+
+```dotenv
+# ~/.hermes/.env
+SIMPLEX_PROFILE=simplex-admin
+SIMPLEX_REQUIRE_PAIRING=true
 ```
 
 ### Google Chat
@@ -96,15 +100,15 @@ Google Chat is the cleanest Workspace choice for Google Workspace teams that do 
 
 Typical posture:
 
-```yaml
-gateways:
-  google_chat:
-    enabled: true
-    project_id: ${GOOGLE_CLOUD_PROJECT}
-    credentials_json: ${GOOGLE_CHAT_CREDENTIALS_JSON}
-    allowed_spaces:
-      - ${GOOGLE_CHAT_ADMIN_SPACE}
-    trust_label: medium
+```bash
+hermes gateway setup
+```
+
+```dotenv
+# ~/.hermes/.env
+GOOGLE_CLOUD_PROJECT=...
+GOOGLE_CHAT_CREDENTIALS_JSON=...
+GOOGLE_CHAT_ADMIN_SPACE=...
 ```
 
 Keep public/customer-facing spaces in quarantine profile until identity mapping and approval routing are proven.

--- a/part17-mcp-servers.md
+++ b/part17-mcp-servers.md
@@ -91,15 +91,15 @@ mcp_servers:
   postgres:
     command: npx
     args: ["-y", "@modelcontextprotocol/server-postgres", "${DATABASE_URL}"]
-    enabled_for:                     # Only load in these sessions
-      - profile: engineering
-      - channel: "#data-questions"
-    tools_allowlist:                 # Only expose these tools
-      - query
-      - describe_table
+    sampling:
+      enabled: false
+    tools:
+      include:                       # Only expose these tools
+        - query
+        - describe_table
 ```
 
-Without a `tools_allowlist`, every tool the server exposes is available.
+Without `tools.include` or `tools.exclude`, every tool the server exposes is available. For profile/channel scoping, keep separate Hermes profiles or separate gateway channel prompts/toolsets rather than using an MCP-local `enabled_for` block.
 
 ---
 
@@ -107,7 +107,7 @@ Without a `tools_allowlist`, every tool the server exposes is available.
 
 These are the ones that pay for themselves within a day:
 
-> **2026 reality check:** MCP is also a supply-chain boundary. Prefer official servers, pin package versions, restrict filesystem roots, and keep `allow_sampling: false` unless the server genuinely needs to call an LLM.
+> **2026 reality check:** MCP is also a supply-chain boundary. Prefer official servers, pin package versions, restrict filesystem roots, and explicitly set `sampling.enabled: false` unless the server genuinely needs to call an LLM.
 
 | Server | What it adds | Why you want it |
 |--------|--------------|-----------------|
@@ -194,11 +194,14 @@ mcp_servers:
   scraper:
     command: node
     args: ["./scraper-mcp.js"]
-    allow_sampling: true              # Off by default
-    sampling_model: gpt-5-mini        # Optional: pin a cheaper model for sampling
+    sampling:
+      enabled: true
+      model: openai/gpt-5.5-mini      # Optional: pin a cheaper model for sampling
+      max_rpm: 10
+      timeout: 30
 ```
 
-**Security note:** Sampling means an MCP server can burn your tokens. Only enable it for servers you trust. See [Part 19](./part19-security-playbook.md#layer-5-mcp-and-plugin-trust).
+**Security note:** Sampling means an MCP server can burn your tokens. Leave `sampling.enabled: false` for servers that read untrusted input or do not need LLM calls. See [Part 19](./part19-security-playbook.md#layer-5-mcp-and-plugin-trust).
 
 ---
 
@@ -240,7 +243,7 @@ Use MCP when you want:
 | Server shows connected but 0 tools | Permissions — server's env vars are missing its auth token | Check `env:` entries and that referenced `${VARS}` exist in `.env` |
 | Tools show up in CLI but not Telegram | Gateway process has its own env — restart it after config change | `hermes gateway restart` |
 | Constant reconnects on HTTP server | SSE timeout behind a reverse proxy | Set `proxy_read_timeout 300s` in nginx/Caddy |
-| `sampling not permitted` in server logs | `allow_sampling: false` (default) | Set `allow_sampling: true` in the server's block |
+| `sampling not permitted` in server logs | `sampling.enabled: false` | Set `sampling.enabled: true` in the server's block only when the server needs LLM calls |
 
 ---
 

--- a/part18-coding-agents.md
+++ b/part18-coding-agents.md
@@ -106,21 +106,16 @@ Each specialist has a sweet spot. Let Hermes route:
 A sensible `~/.hermes/config.yaml`:
 
 ```yaml
+_config_version: 28
+
 delegation:
-  default: claude-code
-  routing:
-    - match: { type: refactor, files_changed_gte: 5 }
-      agent: claude-code
-    - match: { type: bugfix, single_file: true }
-      agent: codex
-    - match: { type: explore, repo_tokens_gte: 200000 }
-      agent: gemini-cli
-    - match: { type: dependency_audit }
-      agent: gemini-cli
-    - match: { budget: low }
-      agent: opencode
-      model: moonshot/kimi-k2.6
+  provider: anthropic
+  model: anthropic/claude-sonnet-5
+  max_iterations: 50
+  child_timeout_seconds: 600
 ```
+
+Use Kanban worker lanes for specialist routing (`codex-worker`, `claude-code`, `gemini-cli`, `opencode`) instead of a `delegation.routing` block in `config.yaml`.
 
 ## Mode 1B: Kanban Worker Lanes (Preferred for Long Work)
 

--- a/part19-security-playbook.md
+++ b/part19-security-playbook.md
@@ -214,7 +214,7 @@ For **true egress allowlisting** (block private ranges, block the metadata IP `1
 
 ## Layer 5: MCP and Plugin Trust
 
-MCP servers and plugins are third-party code you give tool access to. Hermes does **not** have per-server `trust:` levels, `allow_sampling`, or `max_concurrent_calls` config knobs. The real controls are credential filtering, tool filtering, and **operator review before install**.
+MCP servers and plugins are third-party code you give tool access to. Hermes does **not** have legacy per-server trust levels, legacy sampling flags, or `max_concurrent_calls` config knobs. The real controls are credential filtering, current `tools.include` / `tools.exclude` filtering, `sampling.enabled`, and **operator review before install**.
 
 Configure servers with the documented [MCP schema](https://hermes-agent.nousresearch.com/docs/reference/mcp-config-reference) and use `tools.include` / `tools.exclude` to expose only the tools you audited:
 

--- a/part21-remote-sandboxes.md
+++ b/part21-remote-sandboxes.md
@@ -262,11 +262,17 @@ Route untrusted MCP servers (see [Part 19](./part19-security-playbook.md#layer-5
 ```yaml
 mcp_servers:
   random-scraper:
-    trust: untrusted
-    run_in_sandbox: e2b-scratch       # Isolate execution
+    # Expose the untrusted server from an isolated container/profile over HTTP/SSE,
+    # then connect Hermes to that isolated endpoint instead of spawning it on host.
+    url: "${RANDOM_SCRAPER_MCP_URL}"
+    sampling:
+      enabled: false
+    tools:
+      include:
+        - scrape_url
 ```
 
-Sandbox catches any malicious behavior — even if the scraper is compromised, it can't touch your host.
+The isolation boundary should be the container/profile that runs the MCP server. Hermes then talks to the scoped endpoint with sampling disabled and a narrow `tools.include` list.
 
 ---
 

--- a/part9-custom-models.md
+++ b/part9-custom-models.md
@@ -48,16 +48,18 @@ hermes model     # choose xAI / SuperGrok OAuth
 ```
 
 ```yaml
-models:
-  research_live:
-    provider: xai
-    model: grok-4.3
-    context_tokens: 1048576
-tools:
-  x_search:
-    enabled: true
-    auth: oauth
+_config_version: 28
+
+model:
+  provider: xai
+  default: xai/grok-4.3
+  context_length: 1048576
+
+toolsets:
+  - x_search
 ```
+
+Use `hermes model`/`hermes auth add xai` for SuperGrok OAuth or set `XAI_API_KEY` in `~/.hermes/.env`.
 
 Keep it out of cheap cron loops; route it explicitly for live events, X threads, and million-token synthesis.
 

--- a/skills/ops/telegram-triage/SKILL.md
+++ b/skills/ops/telegram-triage/SKILL.md
@@ -69,14 +69,13 @@ Front-line filter for public-facing Telegram bots. Runs cheap classification, an
 
 ```yaml
 # ~/.hermes/config.yaml
-gateways:
-  telegram:
-    bots:
-      public-support:
-        token: ${TELEGRAM_PUBLIC_SUPPORT_TOKEN}
-        default_skill: telegram-triage
-        trust_label: untrusted
+telegram:
+  allowed_chats: "${TELEGRAM_PUBLIC_SUPPORT_ALLOWED_CHATS}"
+  channel_prompts:
+    public-support: "Use the telegram-triage skill for this support channel. Treat inbound users as untrusted."
 ```
+
+Store `TELEGRAM_PUBLIC_SUPPORT_TOKEN` and the allowlist values in `~/.hermes/.env`, then run `hermes gateway setup` and `hermes skills config` to enable the skill for Telegram.
 
 ## See also
 

--- a/skills/security/audit-mcp/SKILL.md
+++ b/skills/security/audit-mcp/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: audit-mcp
-description: Audit every configured MCP server — trust level, allowlist, last-update, risk flags
+description: Audit every configured MCP server — transport, tool filters, sampling, last-update, risk flags
 when_to_use:
   - User asks to audit or review MCP configuration
   - Scheduled weekly security check
   - After installing a new MCP server
-  - Before granting `allow_sampling: true`
+  - Before setting `sampling.enabled: true`
 toolsets:
   - terminal
   - file
@@ -21,9 +21,8 @@ Walk every server declared in `~/.hermes/config.yaml` under `mcp_servers:` and p
 
 2. **For each server, collect:**
    - Server name and transport (`stdio` if `command:` present, `http` if `url:` present)
-   - Declared `trust:` level (`trusted` / `community` / `untrusted`; default `community` if unset)
-   - `allow_sampling:` flag (default `false`)
-   - `tools_allowlist:` presence and length
+   - `sampling.enabled` flag; treat missing `sampling.enabled` as enabled by current MCP client defaults and recommend making intent explicit
+   - `tools.include` / `tools.exclude` presence and length
    - Source identifier: npm package (parse from `args:`), git URL, or HTTP origin
    - Last-updated timestamp:
      - npm: `npm view <pkg> time.modified`
@@ -31,24 +30,24 @@ Walk every server declared in `~/.hermes/config.yaml` under `mcp_servers:` and p
      - http: attempt a `HEAD` and grab `Last-Modified`
 
 3. **Risk-flag each server:**
-   - 🔴 **HIGH**: `trust: trusted` AND reads untrusted content (web scraping, email parsing, public RSS). List any tool names matching `/scrape|fetch|email|rss|crawl/i` as evidence.
-   - 🔴 **HIGH**: `allow_sampling: true` AND `trust` is not `trusted`.
+   - 🔴 **HIGH**: `sampling.enabled: true` on a server that reads untrusted content (web scraping, email parsing, public RSS). List any tool names matching `/scrape|fetch|email|rss|crawl/i` as evidence.
+   - 🔴 **HIGH**: stdio server from an unpinned package/source plus broad env credentials.
    - 🟡 **MEDIUM**: last updated > 90 days ago.
-   - 🟡 **MEDIUM**: no `tools_allowlist` for a server with > 10 tools exposed.
+   - 🟡 **MEDIUM**: no `tools.include` for a server with > 10 tools exposed.
    - 🟡 **MEDIUM**: referenced `${VAR}` in `env:` is not set in `~/.hermes/.env`.
-   - 🟢 **LOW**: unscoped `enabled_for`, making the server available in every profile.
+   - 🟢 **LOW**: no explicit `sampling.enabled` setting, making operator intent ambiguous.
 
-4. **Render a table.** Columns: name, transport, trust, sampling, tools-allowed / tools-exposed, last-update age, flags.
+4. **Render a table.** Columns: name, transport, sampling, tools-filter / tools-exposed, credential scope, last-update age, flags.
 
 5. **Summarize next steps.** Group findings by flag color and recommend:
-   - HIGH: "Change `trust:` to `community` or `untrusted`, disable sampling, add tools_allowlist."
+   - HIGH: "Set `sampling.enabled: false`, scope credentials, and add `tools.include`."
    - MEDIUM stale: "Run `npm update <pkg>` or rebuild the git source; verify release notes."
-   - MEDIUM missing allowlist: "Add `tools_allowlist:` with the specific tools you actually use."
+   - MEDIUM missing filter: "Add `tools.include:` with the specific tools you actually use."
 
 6. **Offer to apply fixes.** Ask the user if they'd like to:
-   - Downgrade any `trusted` → `community`
-   - Disable `allow_sampling` on flagged servers
-   - Write a suggested `tools_allowlist` based on `hermes logs` usage history
+   - Set `sampling.enabled: false` on flagged servers
+   - Add or narrow `tools.include`
+   - Scope environment variables to only the credentials each server needs
 
 Never auto-apply without confirmation.
 
@@ -64,13 +63,13 @@ Report as markdown. Paste into Telegram / Discord / dashboard as-is. Example:
 
 ### 🟡 MEDIUM (2)
 - **postgres** — last updated 127 days ago (package @modelcontextprotocol/server-postgres)
-- **github** — no tools_allowlist, 34 tools exposed
+- **github** — no `tools.include`, 34 tools exposed
 
 ### 🟢 LOW (1)
 - **filesystem** — enabled_for empty, loads in every profile
 
 ### Recommendations
-1. Change `random-scraper` to `trust: untrusted` and add tools_allowlist.
+1. Disable sampling for `random-scraper` and add `tools.include`.
 2. `npm update @modelcontextprotocol/server-postgres`.
 3. Scope `github` to the 6 tools actually used in last 30d.
 ```

--- a/templates/config/cost-optimized.yaml
+++ b/templates/config/cost-optimized.yaml
@@ -1,79 +1,103 @@
 # ------------------------------------------------------------
 # Hermes — COST-OPTIMIZED config
 # ------------------------------------------------------------
-# Target: <$5/mo for personal daily-driver usage.
-#   - Gemini Flash / Pro for 90% of calls
-#   - Kimi K2.6 / Moonshot for bulk / background
-#   - Cerebras Qwen 3 32B (free-ish tier) for classification
-#   - Gemini OAuth free tier
-#   - Anthropic Sonnet only when `intent: coding` on complex files
+# Current Hermes config.yaml schema (schema version 28).
+# Target: a low-spend personal daily driver.
+#
+# Cost control in current Hermes is done with:
+#   - a cheap default model/provider
+#   - auxiliary.* models for side tasks
+#   - fallback_providers for resilience
+#   - compression thresholds
+#   - provider-native caching knobs
+# Not with the old top-level routing/models/gateways/telemetry blocks.
 # ------------------------------------------------------------
 
-version: 1
+_config_version: 28
 
-models:
+model:
+  provider: gemini
   default: google/gemini-3.1-flash
-  classification: cerebras/qwen-3-32b
-  long_context: google/gemini-3.1-pro
-  coding: moonshot/kimi-k2.6            # Fallback to Claude only for hard coding
-  coding_complex: anthropic/claude-sonnet-5
-  reasoning: zai/glm
-  providers:
-    google:
-      oauth_enabled: true               # Hermes-managed Gemini OAuth free tier
-      api_key: ${GOOGLE_API_KEY}        # Used only when OAuth is unavailable
-    anthropic:
-      api_key: ${ANTHROPIC_API_KEY}
-      prompt_caching: true              # 90% discount on repeat context
-    openai:
-      api_key: ${OPENAI_API_KEY}        # Required for LightRAG embeddings below
-    moonshot:
-      api_key: ${MOONSHOT_API_KEY}
-    cerebras:
-      api_key: ${CEREBRAS_API_KEY}
-    zai:
-      api_key: ${ZAI_API_KEY}
 
-routing:
-  rules:
-    - intent: classification
-      model: cerebras/qwen-3-32b
-    - intent: coding
-      when: { complexity: high }
-      model: anthropic/claude-sonnet-5
-    - intent: coding
-      model: moonshot/kimi-k2.6
-    - intent: long_context
-      model: google/gemini-3.1-pro
-    - intent: reasoning
-      model: zai/glm
-  prefer_cached: true                   # Reroute if prompt is >80% cache-hit
+fallback_providers:
+  - provider: kimi-coding
+    model: moonshot/kimi-k2.6
+  - provider: openrouter
+    model: google/gemini-3.1-pro
 
-context:
-  compress_trigger_tokens: 32000        # Aggressive — Flash handles small windows
-  compress_model: cerebras/qwen-3-32b
-  preserve_last_k: 4
+compression:
+  enabled: true
+  threshold: 0.40                  # compress earlier to keep cheap-model turns small
+  target_ratio: 0.20
 
-gateways:
-  cli: { enabled: true }
-  telegram:
-    enabled: true
-    fast_mode_default: false            # Fast Mode is a cost premium
-    bots:
-      admin:
-        token: ${TELEGRAM_ADMIN_BOT_TOKEN}
-        allowed_user_ids:
-          - ${TELEGRAM_OWNER_ID}
+auxiliary:
+  compression:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 120
+    extra_body: {}
+  approval:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 30
+    extra_body: {}
+  title_generation:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 30
+    extra_body: {}
+
+openrouter:
+  response_cache: true
+  response_cache_ttl: 300
+  min_coding_score: 0.50
+
+prompt_caching:
+  cache_ttl: 5m
 
 memory:
-  backend: lightrag
-  lightrag:
-    llm_model: google/gemini-3.1-flash
-    embedding_model: openai/text-embedding-3-small
-    # Or fully local: sentence-transformers/all-MiniLM-L6-v2
+  memory_enabled: true
+  user_profile_enabled: true
+  provider: ""
 
-telemetry:
-  level: info
-  alerts:
-    cost_per_hour_usd: 0.50             # ALARM if spending > $0.50/h
-    daily_budget_usd: 0.20              # Hard cap: pause all non-interactive skills
+delegation:
+  provider: kimi-coding
+  model: moonshot/kimi-k2.6
+  max_iterations: 30
+  child_timeout_seconds: 600
+
+telegram:
+  # Bot token and allowed users belong in ~/.hermes/.env:
+  #   TELEGRAM_BOT_TOKEN=...
+  #   TELEGRAM_ALLOWED_USERS=...
+  reactions: false
+  allowed_chats: "${TELEGRAM_ALLOWED_CHATS}"
+
+display:
+  show_cost: true
+  runtime_footer:
+    enabled: true
+    fields: [model, context_pct, cwd]
+
+approvals:
+  mode: smart                      # aux model auto-approves low-risk commands
+  timeout: 60
+  cron_mode: deny
+
+cron:
+  wrap_response: true
+  max_parallel_jobs: 1
+
+logging:
+  level: INFO
+  max_size_mb: 5
+  backup_count: 3
+
+security:
+  redact_secrets: true
+  tirith_enabled: true
+
+# Credential hints for ~/.hermes/.env:
+#   GEMINI_API_KEY=...              # or GOOGLE_API_KEY / Gemini OAuth via hermes auth
+#   KIMI_API_KEY=...                # Kimi/Moonshot fallback
+#   OPENROUTER_API_KEY=...          # fallback/cache route

--- a/templates/config/minimum.yaml
+++ b/templates/config/minimum.yaml
@@ -1,31 +1,43 @@
 # ------------------------------------------------------------
 # Hermes — MINIMUM config
 # ------------------------------------------------------------
-# The smallest possible working setup:
-#   - 1 provider (Anthropic)
-#   - 1 gateway (CLI only; no Telegram/Discord)
-#   - No memory backend (vector only)
-#   - No MCP servers
-# For when you just want to see Hermes work before committing to more.
+# Current Hermes config.yaml schema (schema version 28).
+# Pair with ~/.hermes/.env for secrets, or run:
+#   hermes setup
+#   hermes model
+#
+# This is intentionally small: CLI chat, one built-in provider, built-in
+# memory, default compression, and manual approval for dangerous commands.
 # ------------------------------------------------------------
 
-version: 1
+_config_version: 28
 
-models:
+model:
+  provider: anthropic
   default: anthropic/claude-sonnet-5
-  providers:
-    anthropic:
-      api_key: ${ANTHROPIC_API_KEY}
 
-gateways:
-  cli:
-    enabled: true
+toolsets:
+  - hermes-cli
 
 memory:
-  backend: vector
-  vector:
-    driver: qdrant
-    path: ~/.hermes/vector
+  memory_enabled: true
+  user_profile_enabled: true
+  provider: ""                    # built-in memory only; no external provider
 
-# Everything else uses Hermes defaults. Run `hermes dashboard` later
-# to layer on skills, platforms, MCP servers, etc.
+compression:
+  enabled: true
+  threshold: 0.50
+  target_ratio: 0.20
+
+approvals:
+  mode: manual                     # manual | smart | off
+  timeout: 60
+  cron_mode: deny
+
+security:
+  redact_secrets: true
+  tirith_enabled: true
+
+# Provider credentials belong in ~/.hermes/.env, not config.yaml:
+#   ANTHROPIC_API_KEY=...
+# Or authenticate interactively with `hermes auth` / `hermes model`.

--- a/templates/config/production.yaml
+++ b/templates/config/production.yaml
@@ -1,224 +1,198 @@
 # ------------------------------------------------------------
 # Hermes — PRODUCTION config
 # ------------------------------------------------------------
-# Full-stack, hardened, observable.
-#   - Multi-provider with task-aware routing
-#   - Telegram + Discord + Slack + Google Chat + LINE + Teams + email gateways
-#   - LightRAG + mem0 for cross-device memory
-#   - MCP: GitHub, Postgres, Cloudflare, Linear, filesystem
-#   - Langfuse tracing, cost alerts, eval hooks
-#   - Hardened approval posture
-#   - All scheduled skills wired to cron
+# Current Hermes config.yaml schema (schema version 28).
+# Full-stack, hardened, observable baseline.
+#
+# This file configures recognized config.yaml sections only. Platform
+# credentials, OAuth, MCP catalog installs, and cron job creation are still
+# best handled by the current CLIs:
+#   hermes model
+#   hermes gateway setup
+#   hermes mcp add ... / hermes mcp install ...
+#   hermes cron create ...
 # ------------------------------------------------------------
 
-version: 1
+_config_version: 28
 
-models:
+model:
+  provider: anthropic
   default: anthropic/claude-sonnet-5
-  classification: google/gemini-3.1-flash
-  long_context: google/gemini-3.1-pro
-  coding: anthropic/claude-sonnet-5
-  reasoning: openai/gpt-5.5
-  cheap: moonshot/kimi-k2.6
-  live_search: xai/grok-4.3
-  providers:
-    anthropic:
-      api_key: ${ANTHROPIC_API_KEY}
-      prompt_caching: true
-    openai:
-      api_key: ${OPENAI_API_KEY}
-    google:
-      api_key: ${GOOGLE_API_KEY}
-      oauth_enabled: true            # Use Gemini OAuth when available
-    moonshot:
-      api_key: ${MOONSHOT_API_KEY}
-    zai:
-      api_key: ${ZAI_API_KEY}
-    cerebras:
-      api_key: ${CEREBRAS_API_KEY}
-    xai:
-      api_key: ${XAI_API_KEY}
-      oauth_enabled: true            # SuperGrok OAuth when available
 
-routing:
-  # See Part 20 — the rules that drop spend ~90% on typical workloads
-  rules:
-    - intent: classification
-      model: google/gemini-3.1-flash
-    - intent: coding
-      model: anthropic/claude-sonnet-5
-    - intent: long_context
-      when: { tokens_in: { gt: 200000 } }
-      model: google/gemini-3.1-pro
-    - intent: reasoning
-      when: { needs_deep_reasoning: true }
-      model: openai/gpt-5.5
-    - intent: bulk_data
-      model: moonshot/kimi-k2.6
-    - intent: live_search
-      model: xai/grok-4.3
+fallback_providers:
+  - provider: gemini
+    model: google/gemini-3.1-pro
+  - provider: kimi-coding
+    model: moonshot/kimi-k2.6
+  - provider: xai
+    model: xai/grok-4.3
 
-gateways:
-  cli: { enabled: true }
-  dashboard:
-    enabled: true
-    listen: 127.0.0.1:8765          # Bind loopback only; expose via Caddy
-  telegram:
-    enabled: true
-    bots:
-      admin:
-        token: ${TELEGRAM_ADMIN_BOT_TOKEN}
-        allowed_user_ids:
-          - ${TELEGRAM_OWNER_ID}
-        trust_label: high
-  discord:
-    enabled: true
-    bot_token: ${DISCORD_BOT_TOKEN}
-    trust_label: medium
-    approval_in_dm_only: true
-  slack:
-    enabled: true
-    signing_secret: ${SLACK_SIGNING_SECRET}
-    bot_token: ${SLACK_BOT_TOKEN}
-    trust_label: medium
-  google_chat:
-    enabled: false                    # Enable after Workspace app + allowlists are configured
-    project_id: ${GOOGLE_CLOUD_PROJECT}
-    credentials_json: ${GOOGLE_CHAT_CREDENTIALS_JSON}
-    allowed_spaces:
-      - ${GOOGLE_CHAT_ADMIN_SPACE}
-    trust_label: medium
-  teams:
-    enabled: false                    # v0.14 end-to-end Graph/listener/delivery path
-    tenant_id: ${MICROSOFT_TENANT_ID}
-    client_id: ${MICROSOFT_TEAMS_CLIENT_ID}
-    client_secret: ${MICROSOFT_TEAMS_CLIENT_SECRET}
-    allowed_teams:
-      - ${MICROSOFT_TEAMS_ADMIN_TEAM}
-    trust_label: medium
-  line:
-    enabled: false
-    channel_access_token: ${LINE_CHANNEL_ACCESS_TOKEN}
-    channel_secret: ${LINE_CHANNEL_SECRET}
-    allowed_user_ids:
-      - ${LINE_ADMIN_USER_ID}
-    trust_label: medium
-  simplex:
-    enabled: false
-    profile: simplex-admin
-    require_pairing: true
-    trust_label: medium
-  email:
-    enabled: true
-    imap:
-      host: imap.gmail.com
-      user: "${EMAIL_USER}"
-      password: "${EMAIL_APP_PASSWORD}"
-    smtp:
-      host: smtp.gmail.com
-      user: "${EMAIL_USER}"
-      password: "${EMAIL_APP_PASSWORD}"
-    trust_label: untrusted
+prompt_caching:
+  cache_ttl: 5m
+
+openrouter:
+  response_cache: true
+  response_cache_ttl: 300
+  min_coding_score: 0.65
+
+compression:
+  enabled: true
+  threshold: 0.50
+  target_ratio: 0.20
+  protect_last_n: 20
+  protect_first_n: 3
+
+auxiliary:
+  compression:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 120
+    extra_body: {}
+  approval:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 30
+    extra_body: {}
+  mcp:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 30
+    extra_body: {}
+  title_generation:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 30
+    extra_body: {}
+
+# Platform behavior lives under each platform section. Tokens and allowlists
+# are environment variables set by `hermes gateway setup` or ~/.hermes/.env.
+telegram:
+  reactions: true
+  allowed_chats: "${TELEGRAM_ALLOWED_CHATS}"
+  channel_prompts: {}
+
+discord:
+  require_mention: true
+  free_response_channels: ""
+  allowed_channels: "${DISCORD_ALLOWED_CHANNELS}"
+  auto_thread: true
+  thread_require_mention: false
+  history_backfill: true
+  history_backfill_limit: 50
+  reactions: true
+  channel_prompts: {}
+
+slack:
+  require_mention: true
+  free_response_channels: ""
+  allowed_channels: "${SLACK_ALLOWED_CHANNELS}"
+  channel_prompts: {}
+
+matrix:
+  require_mention: true
+  free_response_rooms: ""
+  allowed_rooms: "${MATRIX_ALLOWED_ROOMS}"
+
+dashboard:
+  show_token_analytics: false
+  public_url: "${HERMES_DASHBOARD_PUBLIC_URL}"
+  oauth:
+    client_id: "${HERMES_DASHBOARD_OAUTH_CLIENT_ID}"
+    portal_url: "${HERMES_DASHBOARD_PORTAL_URL}"
+
+gateway:
+  strict: true
+  media_delivery_allow_dirs: []
+  trust_recent_files: false
+  trust_recent_files_seconds: 600
+
+streaming:
+  enabled: true
+  transport: auto
+  edit_interval: 0.8
+  buffer_threshold: 24
 
 memory:
-  backend: lightrag
-  lightrag:
-    working_dir: ~/.hermes/lightrag
-    llm_model: google/gemini-3.1-flash
-    embedding_model: openai/text-embedding-3-small
-  mem0:
-    enabled: true
-    api_key: ${MEM0_API_KEY}
+  memory_enabled: true
+  user_profile_enabled: true
+  provider: mem0                   # external provider; requires MEM0_API_KEY/plugin support
 
-context:
-  compress_trigger_tokens: 48000
-  compress_model: google/gemini-3.1-flash
-  preserve_last_k: 6
-
+# mcp_servers is still the current config surface for MCP servers. Per-server
+# sampling controls and tool filters use current `sampling.*` and
+# `tools.include` settings.
 mcp_servers:
   github:
     command: npx
     args: [-y, "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PAT}
-    trust: trusted
-    allow_sampling: false
-    tools_allowlist:
-      - get_pull_request
-      - list_pull_requests
-      - get_pull_request_diff
-      - create_issue
-      - add_issue_comment
-      - create_pull_request_review
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PAT}"
+    sampling:
+      enabled: false
+    tools:
+      include:
+        - get_pull_request
+        - list_pull_requests
+        - get_pull_request_diff
+        - create_issue
+        - add_issue_comment
+        - create_pull_request_review
   postgres:
     command: npx
     args: [-y, "@modelcontextprotocol/server-postgres", "${POSTGRES_URL}"]
-    trust: trusted
-    allow_sampling: false
+    sampling:
+      enabled: false
   cloudflare:
     command: npx
     args: [-y, "@cloudflare/mcp-server-cloudflare"]
     env:
       CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN}"
-    trust: trusted
-    allow_sampling: false
+    sampling:
+      enabled: false
   filesystem:
     command: npx
     args:
       - -y
       - "@modelcontextprotocol/server-filesystem"
-      - ${HOME}/Documents
-      - ${HOME}/Projects
-    trust: trusted
+      - "${HOME}/Documents"
+      - "${HOME}/Projects"
+    sampling:
+      enabled: false
+
+approvals:
+  mode: manual
+  timeout: 60
+  cron_mode: deny
+  mcp_reload_confirm: true
+  destructive_slash_confirm: true
+
+privacy:
+  redact_pii: true
 
 security:
-  approval:
-    bypass_subagents:
-      - nightly-backup
-      - weekly-dep-audit
-      - cost-report
-    auto_approve_read: true
-    denylist:
-      - 'rm\s+-rf\s+/'
-      - 'curl\s+.+\|\s*(sh|bash)'
-      - '169\.254\.169\.254'
-      - 'cat\s+~?/?\.?ssh/'
-      - 'aws\s+s3\s+sync\s+.+\s+s3://'
-      - 'ssh-keyscan'
-    require_approval:
-      - { tool: github,  actions: [create_pr, merge_pr, delete_branch] }
-      - { tool: terminal, actions: [exec] }
-      - { tool: email,    actions: [send] }
-      - { tool: twilio,   actions: [send_sms] }
-      - { tool: any_mcp,  sampling: true }
-    approval_channel: telegram_dm
-  secrets:
-    redaction_patterns:
-      - 'sk-[A-Za-z0-9]{40,}'
-      - 'xoxb-[A-Za-z0-9-]{40,}'
-      - 'ghp_[A-Za-z0-9]{36}'
-      - 'github_pat_[A-Za-z0-9_]{80,}'
-      - 'AKIA[0-9A-Z]{16}'
-    memory_write_redaction: true
-  webhook:
-    require_signature: true
-    max_body_bytes: 1048576
-
-telemetry:
-  level: info
-  exporters:
-    langfuse:
-      public_key: ${LANGFUSE_PUBLIC_KEY}
-      secret_key: ${LANGFUSE_SECRET_KEY}
-      host: ${LANGFUSE_HOST}
-  alerts:
-    cost_per_hour_usd: 5.0
-    tokens_per_turn: 30000
-    webhook: ${ALERT_WEBHOOK_URL}
+  redact_secrets: true
+  tirith_enabled: true
+  allow_private_urls: false
+  website_blocklist:
+    enabled: true
+    domains: []
+    shared_files: []
 
 cron:
-  - { name: nightly-backup,     schedule: "0 3 * * *",   task: "/nightly-backup s3://backups/hermes/ 30", notify: telegram_dm }
-  - { name: weekly-dep-audit,   schedule: "0 9 * * 1",   task: "/weekly-dep-audit severity_floor=high",   notify: telegram_dm }
-  - { name: weekly-cost-report, schedule: "0 9 * * 1",   task: "/cost-report window=7d format=markdown",  notify: telegram_dm }
-  - { name: weekly-mcp-audit,   schedule: "0 10 * * 1",  task: "/audit-mcp",                              notify: telegram_dm }
-  - { name: monthly-rotate,     schedule: "0 4 1 * *",   task: "/rotate-secrets webhook_hmac_*",          notify: telegram_dm }
+  wrap_response: true
+  max_parallel_jobs: 3
+
+logging:
+  level: INFO
+  max_size_mb: 10
+  backup_count: 5
+
+display:
+  show_cost: false                  # local lower-bound estimate; provider bill is authoritative
+  runtime_footer:
+    enabled: true
+    fields: [model, context_pct, cwd]
+
+# Scheduled jobs are not config.yaml list entries in current Hermes. Create them with:
+#   hermes cron create "0 3 * * *" "Run the nightly backup skill and summarize the result" --skill nightly-backup --deliver telegram
+#   hermes cron create "0 9 * * 1" "Run dependency audit and report high-severity findings" --skill weekly-dep-audit --deliver telegram
+#   hermes cron create "0 10 * * 1" "Audit configured MCP servers and summarize risk" --skill audit-mcp --deliver telegram

--- a/templates/config/security-hardened.yaml
+++ b/templates/config/security-hardened.yaml
@@ -1,121 +1,118 @@
 # ------------------------------------------------------------
 # Hermes — SECURITY-HARDENED config
 # ------------------------------------------------------------
+# Current Hermes config.yaml schema (schema version 28).
 # For operators whose agent reads untrusted content (public bots,
 # webhook-driven flows, email inbox, GitHub PR comments).
-# Every layer from Part 19 enabled + extras:
-#   - Quarantine mode as default
-#   - Strict approval on everything
-#   - No sampling allowed on community/untrusted MCPs
-#   - Memory-write redaction
-#   - Periodic security crons
+#
+# Current Hermes profiles are separate `hermes profile ...` homes, not a
+# `profiles:` block inside config.yaml. Use separate profiles for quarantine
+# vs. trusted administration when you need hard isolation.
 # ------------------------------------------------------------
 
-version: 1
+_config_version: 28
 
-profile: quarantine                     # Default to quarantine; explicit /trusted to leave
-
-profiles:
-  quarantine:
-    description: Untrusted-input-facing. Cheap model, approval on everything, no memory writes.
-    models: { default: google/gemini-3.1-flash }
-    tools_allowlist: [classify, reply, escalate]
-    memory: { write: false, read: true }
-    security:
-      approval:
-        bypass_subagents: []
-        auto_approve_read: false        # Even reads require approval here
-        require_approval:
-          - { tool: "*", actions: [exec, write, send, create, update, delete] }
-  trusted:
-    description: Admin-only. Full capability.
-    models: { default: anthropic/claude-sonnet-5 }
-
-models:
+model:
+  provider: anthropic
   default: anthropic/claude-sonnet-5
-  providers:
-    anthropic:
-      api_key: "${ANTHROPIC_API_KEY}"
-    google:
-      api_key: "${GOOGLE_API_KEY}"
 
-gateways:
-  cli: { enabled: true, profile: trusted }        # Local CLI = admin
-  telegram:
-    enabled: true
-    bots:
-      admin:
-        token: ${TELEGRAM_ADMIN_BOT_TOKEN}
-        allowed_user_ids:
-          - ${TELEGRAM_OWNER_ID}
-        profile: trusted
-      public:
-        token: ${TELEGRAM_PUBLIC_BOT_TOKEN}
-        profile: quarantine                       # Public bot locked down
-        default_skill: telegram-triage
-  discord:
-    enabled: true
-    bot_token: ${DISCORD_BOT_TOKEN}
-    profile: quarantine
+toolsets:
+  - hermes-cli
+  - web
+  - file
+  - terminal
+
+auxiliary:
+  approval:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 30
+    extra_body: {}
+  mcp:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 30
+    extra_body: {}
+
+telegram:
+  reactions: false
+  allowed_chats: "${TELEGRAM_ALLOWED_CHATS}"
+  channel_prompts: {}
+
+discord:
+  require_mention: true
+  allowed_channels: "${DISCORD_ALLOWED_CHANNELS}"
+  auto_thread: true
+  thread_require_mention: true
+  history_backfill: true
+  reactions: true
+  channel_prompts: {}
+
+approvals:
+  mode: manual                     # always prompt for dangerous commands
+  timeout: 300
+  cron_mode: deny
+  mcp_reload_confirm: true
+  destructive_slash_confirm: true
+
+privacy:
+  redact_pii: true
+
+gateway:
+  strict: true
+  media_delivery_allow_dirs: []
+  trust_recent_files: false
+  trust_recent_files_seconds: 600
 
 security:
-  approval:
-    bypass_subagents: []                # Empty by design
-    auto_approve_read: false            # Even directory listings require approval
-    denylist:
-      - 'rm\s+-rf\s+/'
-      - 'curl\s+.+\|\s*(sh|bash)'
-      - '169\.254\.169\.254'
-      - 'cat\s+~?/?\.?ssh/'
-      - 'aws\s+s3\s+sync'
-      - 'scp\s+.+@'
-      - 'nc\s+-l'
-      - 'base64\s+-d.*\|.*bash'
-    require_approval:
-      - { tool: "*", actions: [exec, write, send, create, update, delete, post] }
-    approval_channel: telegram_dm
-    approval_timeout_seconds: 300       # Reject if operator doesn't respond
-  secrets:
-    # Redaction is on by default in Hermes v0.13+; keep patterns explicit
-    # for auditability and memory/log hygiene.
-    redaction_patterns:
-      - 'sk-[A-Za-z0-9]{40,}'
-      - 'xoxb-[A-Za-z0-9-]{40,}'
-      - 'ghp_[A-Za-z0-9]{36}'
-      - 'github_pat_[A-Za-z0-9_]{80,}'
-      - 'AKIA[0-9A-Z]{16}'
-      - 'eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'     # JWT
-    memory_write_redaction: true
-    log_redaction: true
-  webhook:
-    require_signature: true
-    max_body_bytes: 524288
-    ttl_seconds: 300                    # Reject webhooks older than 5 min
-  mcp:
-    default_trust: untrusted            # Must be explicitly elevated per-server
-    require_allowlist: true
+  redact_secrets: true
+  tirith_enabled: true
+  tirith_timeout: 5
+  tirith_fail_open: false
+  allow_private_urls: false
+  website_blocklist:
+    enabled: true
+    domains:
+      - 169.254.169.254
+    shared_files: []
 
-telemetry:
-  level: info
-  exporters:
-    langfuse:
-      public_key: ${LANGFUSE_PUBLIC_KEY}
-      secret_key: ${LANGFUSE_SECRET_KEY}
-      host: ${LANGFUSE_HOST}
-  alerts:
-    # Tight budget + any injection-attempt pings operator immediately
-    cost_per_hour_usd: 1.0
-    injection_attempts_per_hour: 1
-    webhook: ${ALERT_WEBHOOK_URL}
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+  provider: ""
+
+delegation:
+  subagent_auto_approve: false
+  max_spawn_depth: 1
+  max_iterations: 50
+
+# Keep MCP scopes narrow. Prefer `hermes mcp install`/`hermes mcp configure`
+# so Hermes probes the server and stores a current tools.include list.
+mcp_servers:
+  github:
+    command: npx
+    args: [-y, "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_PAT}"
+    sampling:
+      enabled: false
+    tools:
+      include:
+        - get_pull_request
+        - list_pull_requests
+        - get_pull_request_diff
+        - add_issue_comment
 
 cron:
-  - { name: weekly-mcp-audit,    schedule: "0 9 * * 1",   task: "/audit-mcp",                              notify: telegram_dm }
-  - { name: weekly-bypass-audit, schedule: "0 10 * * 1",  task: "/audit-approval-bypass",                  notify: telegram_dm }
-  - { name: monthly-rotate,      schedule: "0 4 1 * *",   task: "/rotate-secrets all",                     notify: telegram_dm }
-  - { name: daily-log-sweep,     schedule: "0 2 * * *",   task: "/audit-injection-attempts since=24h",     notify: telegram_dm }
-  - name: disk-watchdog
-    schedule: "*/15 * * * *"
-    mode: no_agent                  # v0.13: script-only, no LLM session
-    command: >-
-      df -h / | awk 'NR==2 && $5+0 > 85 {print "Disk usage high: "$5}'
-    notify: telegram_dm
+  wrap_response: true
+  max_parallel_jobs: 1
+
+logging:
+  level: INFO
+  max_size_mb: 10
+  backup_count: 5
+
+# Create recurring security work with the current cron CLI, for example:
+#   hermes cron create "0 9 * * 1" "Audit MCP server configuration and summarize risk" --skill audit-mcp --deliver telegram
+#   hermes cron create "0 10 * * 1" "Audit approval bypasses and report any drift" --skill audit-approval-bypass --deliver telegram
+#   hermes cron create "0 4 1 * *" "Rotate configured secrets according to the rotate-secrets skill" --skill rotate-secrets --deliver telegram

--- a/templates/config/telegram-bot.yaml
+++ b/templates/config/telegram-bot.yaml
@@ -1,86 +1,75 @@
 # ------------------------------------------------------------
 # Hermes — TELEGRAM BOT config
 # ------------------------------------------------------------
-# Opinionated setup for a personal Telegram assistant:
-#   - Anthropic primary + Gemini Flash for classification
-#   - OpenAI embeddings for LightRAG memory
-#   - Telegram gateway with a private admin DM + (optional) public bot
-#   - LightRAG memory backend
-#   - Sensible approval defaults
-#   - Ready for the telegram-triage skill on public bot
+# Current Hermes config.yaml schema (schema version 28).
+# Opinionated setup for a private Telegram assistant.
+#
+# Configure the Telegram token/allowed users with:
+#   hermes gateway setup
+# or put secrets in ~/.hermes/.env:
+#   TELEGRAM_BOT_TOKEN=...
+#   TELEGRAM_ALLOWED_USERS=...
 # ------------------------------------------------------------
 
-version: 1
+_config_version: 28
 
-models:
+model:
+  provider: anthropic
   default: anthropic/claude-sonnet-5
-  classification: google/gemini-3.1-flash
-  providers:
-    anthropic:
-      api_key: ${ANTHROPIC_API_KEY}
-      prompt_caching: true
-    google:
-      api_key: ${GOOGLE_API_KEY}
-    openai:
-      api_key: ${OPENAI_API_KEY}
 
-gateways:
-  cli:
-    enabled: true
-  telegram:
-    enabled: true
-    bots:
-      # Primary / admin bot — this is YOU
-      admin:
-        token: ${TELEGRAM_ADMIN_BOT_TOKEN}
-        allowed_user_ids:
-          - ${TELEGRAM_OWNER_ID}
-        trust_label: high
-        default_skill: default
-      # Public bot — strangers talk to this one (optional, comment out to skip)
-      # public:
-      #   token: ${TELEGRAM_PUBLIC_BOT_TOKEN}
-      #   trust_label: untrusted
-      #   default_skill: telegram-triage
+prompt_caching:
+  cache_ttl: 5m
+
+auxiliary:
+  compression:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 120
+    extra_body: {}
+  approval:
+    provider: gemini
+    model: google/gemini-3.1-flash
+    timeout: 30
+    extra_body: {}
+
+telegram:
+  reactions: true
+  allowed_chats: "${TELEGRAM_ALLOWED_CHATS}"  # optional group/topic whitelist
+  channel_prompts: {}
+
+display:
+  platforms:
+    telegram:
+      streaming: true
+  runtime_footer:
+    enabled: false
+
+streaming:
+  enabled: false                    # turn on only if you want progressive Telegram drafts
+  transport: auto
 
 memory:
-  backend: lightrag
-  lightrag:
-    working_dir: ~/.hermes/lightrag
-    llm_model: google/gemini-3.1-flash
-    embedding_model: openai/text-embedding-3-small
+  memory_enabled: true
+  user_profile_enabled: true
+  provider: ""                      # built-in memory; use `hermes memory setup` for external providers
+
+approvals:
+  mode: manual
+  timeout: 60
+  cron_mode: deny
 
 security:
-  approval:
-    bypass_subagents: []               # Start empty; add after review
-    auto_approve_read: true
-    denylist:
-      - 'rm\s+-rf\s+/'
-      - 'curl\s+.+\|\s*(sh|bash)'
-      - '169\.254\.169\.254'           # AWS/GCP metadata IP
-      - 'cat\s+~?/?\.?ssh/'
-    require_approval:
-      - tool: github
-        actions: [create_pr, merge_pr, delete_branch]
-      - tool: terminal
-        actions: [exec]
-      - tool: any_mcp
-        sampling: true
-    approval_channel: telegram_dm       # Always DM, never group
-  secrets:
-    # Redaction is on by default in Hermes v0.13+; keep patterns explicit
-    # so hardened deployments know what is being scrubbed.
-    redaction_patterns:
-      - 'sk-[A-Za-z0-9]{40,}'           # OpenAI / Anthropic style
-      - 'xoxb-[A-Za-z0-9-]{40,}'        # Slack bot
-      - 'ghp_[A-Za-z0-9]{36}'           # GitHub PAT
-      - 'AKIA[0-9A-Z]{16}'              # AWS access key id
+  redact_secrets: true
+  tirith_enabled: true
+  allow_private_urls: false
 
-telemetry:
-  level: info
-  # Uncomment when you add Langfuse (see templates/compose/langfuse-stack.yml)
-  # exporters:
-  #   langfuse:
-  #     public_key: ${LANGFUSE_PUBLIC_KEY}
-  #     secret_key: ${LANGFUSE_SECRET_KEY}
-  #     host: http://localhost:3000
+gateway:
+  strict: true                      # safer for chat-facing deployments
+  trust_recent_files: true
+  trust_recent_files_seconds: 600
+
+# Credential hints for ~/.hermes/.env:
+#   ANTHROPIC_API_KEY=...
+#   GEMINI_API_KEY=...              # auxiliary compression/approval
+#   TELEGRAM_BOT_TOKEN=...
+#   TELEGRAM_ALLOWED_USERS=...


### PR DESCRIPTION
## Summary
- Update config templates and wizard output to current Hermes _config_version 28 schema
- Replace stale top-level models/gateways/routing/telemetry examples in docs and skills
- Keep mcp_servers as current, but update MCP examples to sampling.enabled and tools.include

## Validation
- stale config-key scan over templates/docs/skills/part*.md: no matches
- YAML parse for all yaml/yml files: ok
- hermes config check for all templates/config/*.yaml: Config version 28 ✓
- skill frontmatter validation: all 13 skills passed
- docs/wizard JS syntax and generated persona YAML: ok
- yamllint on normalized CI-style copy of templates/ benchmarks/ skills/: ok

Note: benchmarks/matrix.yaml intentionally keeps models: as benchmark matrix schema, not Hermes config.yaml.