### PR TITLE
docs: refresh Part 19 security playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Dated list of meaningful guide updates. Roughly [Keep a Changelog](https://keepachangelog.com) flavored.
 
+## 2026-06-29 — Part 19 security playbook refresh
+
+### Changed
+- **Part 19 — Security Playbook**: refreshed against current Hermes security docs and source. Corrected `command_allowlist` wording, updated tirith defaults/behavior, expanded env and credential passthrough guidance, replaced stale SSH/Docker examples, added `security.website_blocklist`, `security.allow_private_urls`, `HERMES_WRITE_SAFE_ROOT`, supply-chain advisory acknowledgements, and `security.allow_lazy_installs` hardening notes.
+
 ## 2026-06-17 — Hermes v0.16.0 "Surface" Refresh
 
 ### Added

--- a/part19-security-playbook.md
+++ b/part19-security-playbook.md
@@ -1,8 +1,8 @@
 # Part 19: Security Playbook — Locking Down an Agent That Reads Untrusted Text
 
-*April 15, 2026 published [Comment and Control](https://oddguan.com/blog/comment-and-control-prompt-injection-credential-theft-claude-code-gemini-cli-github-copilot/) — cross-vendor prompt injection that steals GitHub Actions secrets from Claude Code, Gemini CLI, and Copilot Agent via PR titles. Your Hermes bot reads messages from Telegram, Discord, email, webhooks, and SMS — every one of them an injection vector. This part is the defensive posture that stops your agent from becoming someone else's command-and-control channel.*
+_April 15, 2026 published [Comment and Control](https://oddguan.com/blog/comment-and-control-prompt-injection-credential-theft-claude-code-gemini-cli-github-copilot/) — cross-vendor prompt injection that steals GitHub Actions secrets from Claude Code, Gemini CLI, and Copilot Agent via PR titles. Your Hermes bot reads messages from Telegram, Discord, email, webhooks, and SMS — every one of them an injection vector. This part is the defensive posture that stops your agent from becoming someone else's command-and-control channel._
 
-> **Schema note (2026-05-31):** Earlier revisions of this part documented a `security:` config block with `provenance`, `approval.require_approval` regex, `secrets.scope`, and `network.egress_allowlist` keys. **None of those exist in Hermes Agent.** This rev is rewritten against the real schema — top-level [`approvals:`](https://hermes-agent.nousresearch.com/docs/user-guide/security), a native dangerous-command detector, `command_allowlist:`, `.env` user allowlists, and OS-level isolation. See the [official Security guide](https://hermes-agent.nousresearch.com/docs/user-guide/security) and [SECURITY.md trust model](https://github.com/NousResearch/hermes-agent/blob/main/SECURITY.md).
+> **Schema note (updated 2026-06-29):** Earlier revisions of this part documented a `security:` config block with `provenance`, `approval.require_approval` regex, `secrets.scope`, and `network.egress_allowlist` keys. **None of those exist in Hermes Agent.** This rev tracks the real schema: top-level [`approvals:`](https://hermes-agent.nousresearch.com/docs/user-guide/security), native dangerous-command detection, `command_allowlist:`, `.env` user allowlists and DM pairing, `security.redact_secrets`, `security.tirith_*`, `security.website_blocklist`, `security.allow_private_urls`, supply-chain advisory acks, lazy-install controls, env/credential passthrough, and OS-level isolation. See the [official Security guide](https://hermes-agent.nousresearch.com/docs/user-guide/security) and [SECURITY.md trust model](https://github.com/NousResearch/hermes-agent/blob/main/SECURITY.md).
 
 ---
 
@@ -10,19 +10,19 @@
 
 Hermes is uniquely exposed because it takes input from **many** surfaces and has **many** capabilities:
 
-| Surface | Attacker controls | Risk |
-|---------|-------------------|------|
-| Telegram DM | Message body, filename, image caption | Injection → tool calls |
-| Discord channel | Embed text, webhook payloads, usernames | Injection → tool calls |
-| Email inbox | Headers, body, attachment filenames | Multi-stage (HTML + links) |
-| SMS / Twilio | Message body + webhook payloads | Injection → tool calls |
-| GitHub MCP | PR titles, issue bodies, comments | Comment-and-Control pattern |
-| Web-scraped content | Page HTML the agent reads | "Read then act" injections |
-| Voice transcript | STT transcription | "Say the magic phrase" attacks |
-| MCP/plugin package | Tool schema, stdout, hook behavior | Supply-chain prompt injection / token burn |
-| Dashboard plugin | Browser UI + backend endpoints | Local secret/config exposure |
+| Surface             | Attacker controls                       | Risk                                       |
+| ------------------- | --------------------------------------- | ------------------------------------------ |
+| Telegram DM         | Message body, filename, image caption   | Injection → tool calls                     |
+| Discord channel     | Embed text, webhook payloads, usernames | Injection → tool calls                     |
+| Email inbox         | Headers, body, attachment filenames     | Multi-stage (HTML + links)                 |
+| SMS / Twilio        | Message body + webhook payloads         | Injection → tool calls                     |
+| GitHub MCP          | PR titles, issue bodies, comments       | Comment-and-Control pattern                |
+| Web-scraped content | Page HTML the agent reads               | "Read then act" injections                 |
+| Voice transcript    | STT transcription                       | "Say the magic phrase" attacks             |
+| MCP/plugin package  | Tool schema, stdout, hook behavior      | Supply-chain prompt injection / token burn |
+| Dashboard plugin    | Browser UI + backend endpoints          | Local secret/config exposure               |
 
-The goal isn't to eliminate these channels — Hermes is *for* reading them. The goal is to make sure untrusted text can't cross a trust boundary into secrets, writes, or shell.
+The goal isn't to eliminate these channels — Hermes is _for_ reading them. The goal is to make sure untrusted text can't cross a trust boundary into secrets, writes, or shell.
 
 ---
 
@@ -36,8 +36,8 @@ Every in-process control below (approval prompts, secret redaction, skill scanni
 
 Hermes supports two OS-level isolation postures — choose deliberately:
 
-- **Terminal-backend isolation.** A non-default `terminal.backend` (Docker, Singularity, Modal, Daytona, SSH) runs LLM-emitted shell *and* file-tool operations inside a container/remote host. Confines anything the agent does *through the shell*. Does **not** confine the agent's own Python process (code-execution tool, MCP subprocesses, plugins, hooks, skills).
-- **Whole-process wrapping.** Runs the entire agent process tree in a sandbox so *every* path — shell, code-exec, MCP, file tools, plugins, hooks — is subject to one filesystem/network/process policy. Hermes supports this via its own Docker/Compose setup, or via [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) for declarative filesystem + **L7 network egress** + syscall + inference-routing policy.
+- **Terminal-backend isolation.** A non-default `terminal.backend` (Docker, Singularity, Modal, Daytona, SSH) runs LLM-emitted shell _and_ file-tool operations inside a container/remote host. Confines anything the agent does _through the shell_. Does **not** confine the agent's own Python process (code-execution tool, MCP subprocesses, plugins, hooks, skills).
+- **Whole-process wrapping.** Runs the entire agent process tree in a sandbox so _every_ path — shell, code-exec, MCP, file tools, plugins, hooks — is subject to one filesystem/network/process policy. Hermes supports this via its own Docker/Compose setup, or via [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) for declarative filesystem + **L7 network egress** + syscall + inference-routing policy.
 
 If your agent ingests content from surfaces you don't control (the open web, inbound email, multi-user channels, untrusted MCP servers), **whole-process wrapping is the supported posture.** Running the default local backend against untrusted input is operating outside Hermes' supported security model. The layers below harden a real deployment; they are not a substitute for the boundary.
 
@@ -45,7 +45,7 @@ If your agent ingests content from surfaces you don't control (the open web, inb
 
 ## Layer 1: User Authorization — Who Can Talk to the Agent
 
-The first gate is *who is even allowed to reach the agent*. On every messaging gateway, Hermes is **default-deny**: if no allowlist is configured and `GATEWAY_ALLOW_ALL_USERS` is unset, all users are rejected.
+The first gate is _who is even allowed to reach the agent_. On every messaging gateway, Hermes is **default-deny**: if no allowlist is configured and `GATEWAY_ALLOW_ALL_USERS` is unset, all users are rejected.
 
 Set per-platform allowlists in `~/.hermes/.env` (comma-separated IDs):
 
@@ -70,9 +70,9 @@ Per-platform hardening worth setting:
 ```yaml
 # ~/.hermes/config.yaml
 discord:
-  require_mention: true          # Bot only responds when @mentioned in channels (default)
-  free_response_channels: ""     # Channel IDs exempt from the mention requirement
-group_sessions_per_user: true    # Each group participant gets an isolated session
+  require_mention: true # Bot only responds when @mentioned in channels (default)
+  free_response_channels: "" # Channel IDs exempt from the mention requirement
+group_sessions_per_user: true # Each group participant gets an isolated session
 ```
 
 ---
@@ -86,32 +86,33 @@ Configure the policy with the top-level `approvals:` block:
 ```yaml
 # ~/.hermes/config.yaml
 approvals:
-  mode: manual                    # manual | smart | off
-  timeout: 60                     # seconds to wait before fail-closed deny
-  cron_mode: deny                 # deny | approve — behavior when a cron job hits a dangerous command
-  mcp_reload_confirm: true        # /reload-mcp confirms before invalidating the MCP tool cache
+  mode: manual # manual | smart | off
+  timeout: 60 # seconds to wait before fail-closed deny
+  cron_mode: deny # deny | approve — behavior when a cron job hits a dangerous command
+  mcp_reload_confirm: true # /reload-mcp confirms before invalidating the MCP tool cache
   destructive_slash_confirm: true # /clear, /new, /reset, /undo confirm before discarding state
 ```
 
-| Mode | Behavior |
-|------|----------|
-| **manual** (default) | Always prompt on a dangerous command |
-| **smart** | An auxiliary LLM assesses risk first — auto-approves clearly low-risk matches, auto-denies clearly dangerous ones, escalates the uncertain middle to a manual prompt |
-| **off** | Skip all approval prompts (equivalent to `--yolo`) |
+| Mode                 | Behavior                                                                                                                                                             |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **manual** (default) | Always prompt on a dangerous command                                                                                                                                 |
+| **smart**            | An auxiliary LLM assesses risk first — auto-approves clearly low-risk matches, auto-denies clearly dangerous ones, escalates the uncertain middle to a manual prompt |
+| **off**              | Skip all approval prompts (equivalent to `--yolo`)                                                                                                                   |
 
-When a prompt fires in the CLI you get four choices — **once / session / always / deny** (deny is the default if you time out). On messaging platforms the prompt is delivered as a message (inline buttons on Telegram/Discord/Slack); reply *yes/approve* or *no/deny*.
+When a prompt fires in the CLI you get four choices — **once / session / always / deny** (deny is the default if you time out). On messaging platforms the prompt is delivered as a message (inline buttons on Telegram/Discord/Slack); reply _yes/approve_ or _no/deny_.
 
 ### `command_allowlist` — the "always approve" list
 
-Choosing **always** writes a human-readable pattern description to the top-level `command_allowlist:`:
+Choosing **always** writes the detector pattern that fired to the top-level `command_allowlist:`:
 
 ```yaml
+# Permanently allowed dangerous command patterns
 command_allowlist:
-  - recursive delete                       # matches the "rm -r" detector category
-  - shell command via -c/-lc flag
+  - rm
+  - systemctl
 ```
 
-Entries are description strings that match the detector's pattern categories — they are **not** raw regex. Be conservative: allowing `recursive delete` means *every* `rm -r`, including paths you didn't intend, runs without a prompt. Edit `~/.hermes/config.yaml` (or `hermes config edit`) to remove entries.
+These entries are pattern strings consumed by the built-in detector — not your own regex language, and not a path-scoped policy. Be conservative: allowing a broad pattern can silently approve future commands you did not intend. Periodically run `hermes config edit` and remove stale allowlist entries.
 
 ### YOLO mode — what it does and doesn't bypass
 
@@ -127,94 +128,138 @@ A small set of catastrophic, irreversible commands is refused **regardless** of 
 - `dd if=/dev/zero of=/dev/sd*`
 - Piping untrusted URLs to `sh` at the rootfs top level
 
-The blocklist trips *before* the approval layer sees the command. It's the seatbelt, not the whole car.
+The blocklist trips _before_ the approval layer sees the command. It's the seatbelt, not the whole car.
 
 ### Two caveats that matter
 
-- **Container backends skip approval entirely.** When `terminal.backend` is `docker`, `singularity`, `modal`, or `daytona`, dangerous-command checks are bypassed because the container *is* the boundary (Layer "OS isolation" above). That's the intended trade — unrestricted execution inside a disposable box.
+- **Container backends skip approval entirely.** When `terminal.backend` is `docker`, `singularity`, `modal`, or `daytona`, dangerous-command checks are bypassed because the container _is_ the boundary (Layer "OS isolation" above). That's the intended trade — unrestricted execution inside a disposable box.
 - **Approvals route to the channel the message came from.** There is no separate "approval channel" config. The defense against "trick the bot into approving itself" is your **allowlist** (Layer 1): keep the public-facing bot's allowlist tight, and drive privileged actions from a separate, owner-only bot or DM that untrusted users can't reach.
 
-### Optional: tirith pre-exec scanning
+### Tirith pre-exec scanning
 
-Hermes can layer [tirith](https://hermes-agent.nousresearch.com/docs/user-guide/security) on top of the native detector to catch homograph URLs, pipe-to-shell, terminal injection, and env manipulation:
+Hermes layers [tirith](https://github.com/sheeki03/tirith) on top of the native detector to catch homograph URLs, pipe-to-interpreter patterns (`curl | bash`, `wget | sh`), and terminal-injection tricks. It is enabled by default and auto-installs a prebuilt binary on first use with SHA-256 checksum verification (plus cosign provenance verification when `cosign` is available):
 
 ```yaml
 security:
-  tirith_enabled: true
-  tirith_path: tirith
+  tirith_enabled: true # default: true
+  tirith_path: "tirith" # PATH lookup by default
   tirith_timeout: 5
-  tirith_fail_open: true   # allow commands if tirith is unavailable
+  tirith_fail_open: true # default: allow execution if tirith is unavailable
 ```
 
-A tirith `warn` is folded into the same approval prompt; a tirith `block` rejects the command outright.
+Set `tirith_fail_open: false` in high-security environments. Tirith's verdict joins the same approval flow: safe commands pass; suspicious or blocked commands prompt with findings, safer alternatives, and a default-deny choice. On platforms without a prebuilt tirith binary, use WSL/Linux or rely on the built-in pattern detector.
 
 ---
 
-## Layer 3: Secrets and Credential Scoping
+## Layer 3: Secrets, Credential Scoping, and Explicit Passthrough
 
-The Comment-and-Control attack class succeeds by exfiltrating credentials. Hermes' defenses here reduce *casual* leakage — pair them with isolation for real containment.
+The Comment-and-Control attack class succeeds by exfiltrating credentials. Hermes' defenses here reduce _casual_ leakage — pair them with isolation for real containment.
 
-**On-disk hygiene (automatic):**
+**On-disk hygiene:**
 
-- API keys live only in `~/.hermes/.env`, created `0600`; the `~/.hermes/` directory is `0700`.
-- Keys are **never** written to `config.yaml`, committed, or returned in tool output.
+- API keys belong in `~/.hermes/.env`, not `config.yaml` or the repo. Keep the file `0600` and the profile directory private.
+- Redaction is pattern-based, not magic. Never assume every credential-like value is scrubbed; review logs and bundles before sharing.
 
 **Output / log redaction:**
 
 ```yaml
 # ~/.hermes/config.yaml
 security:
-  redact_secrets: true   # default on — redacts secret-like patterns from tool output and logs
+  redact_secrets: true # default on — redacts secret-like patterns from tool output, logs, and chat responses
 ```
 
-Leave it on. `~/.hermes/logs/` is redacted by default; only set `redact_secrets: false` to debug an auth issue, and treat the resulting logs as secret-bearing.
+Leave it on. The toggle is bridged into `HERMES_REDACT_SECRETS` at startup, so changing it mid-session does not necessarily affect already-imported code. If you disable it to debug auth, restart afterward and treat the resulting logs as secret-bearing.
 
-**Credential scoping (automatic):** Hermes filters the environment it hands to its lower-trust in-process children — shell subprocesses, MCP subprocesses, and the code-execution child. Provider API keys and gateway tokens are **stripped by default**; only variables an operator or a loaded skill explicitly declares are passed through. You don't configure per-tool secret scoping — it's the default behavior.
+**Default child-process filtering:** Hermes filters the environment it hands to lower-trust children.
 
-> **The honest caveat (from SECURITY.md §2.3):** this reduces casual exfiltration; it is *not* containment. Anything running *inside* the agent process — skills, plugins, hook handlers — can read whatever the agent can, including in-memory credentials. The mitigation for a hostile in-process component is operator review before install (Layer 5), not env scrubbing.
+| Child surface         | Default behavior                                                                                                          | How to pass a needed credential                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `execute_code`        | Blocks env vars whose names look secret-bearing (`KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `AUTH`, etc.) except safe prefixes | Load a skill whose frontmatter declares `required_environment_variables`, or add `terminal.env_passthrough` |
+| Local `terminal`      | Blocks explicit Hermes infrastructure/provider/gateway/tool secrets                                                       | `terminal.env_passthrough` or skill-declared required env vars                                              |
+| Docker/Modal terminal | No host env by default                                                                                                    | Skill-declared passthrough, `terminal.env_passthrough`, or `terminal.docker_forward_env` for Docker         |
+| Credential files      | Not mounted by default                                                                                                    | Skill `required_credential_files` or `terminal.credential_files`; Docker mounts read-only                   |
+| MCP stdio             | Only safe system vars (`PATH`, `HOME`, `USER`, locale/shell/tmp, `XDG_*`) plus the server's own `env:`                    | Put exactly what the server needs in `mcp_servers.<name>.env`                                               |
+
+Example:
+
+```yaml
+terminal:
+  env_passthrough:
+    - TENOR_API_KEY # task-specific key, not Hermes provider keys
+  credential_files:
+    - google_token.json # relative to ~/.hermes/; mounted read-only in Docker
+```
+
+> **The honest caveat (from SECURITY.md §2.3):** filtering reduces accidental exfiltration; it is _not_ containment. Anything running _inside_ the agent process — skills, plugins, hook handlers — can read what the agent can. The mitigation for a hostile in-process component is operator review before install (Layer 5) and whole-process isolation, not env scrubbing.
 
 ---
 
 ## Layer 4: Isolation Backends — Where Egress Control Actually Lives
 
-There is no `security.network.egress_allowlist` in Hermes. Network egress control, filesystem confinement, and "the agent can't read its own `.env`" all come from the **terminal backend** or a **whole-process sandbox** — not a config key in a `security:` block.
+There is no `security.network.egress_allowlist` in Hermes. Filesystem confinement and broad network control come from the **terminal backend** or a **whole-process sandbox** — not a single config key in a `security:` block. Hermes does, however, now ship URL-fetching guardrails (website blocklist + SSRF protection), covered below.
 
 Pick a non-default terminal backend so LLM-emitted shell and file-tool operations run off your host:
 
 ```yaml
 # ~/.hermes/config.yaml
 terminal:
-  backend: docker                         # local | docker | singularity | modal | daytona | ssh
-  docker_image: nikolaik/python-nodejs:python3.11-nodejs20
+  backend: docker
+  docker_image: "nikolaik/python-nodejs:python3.11-nodejs20"
   cwd: /workspace
-  docker_mount_cwd_to_workspace: false    # off by default — opt in to mount host cwd
-  container_persistent: true              # persist FS across sessions; false = reset each session
+  docker_forward_env: [] # explicit env allowlist only; empty keeps host secrets out
+  container_cpu: 1
+  container_memory: 5120 # MB
+  container_disk: 51200 # MB
+  container_persistent: true # persist /workspace and /root under ~/.hermes/sandboxes/docker/<task_id>/
 ```
 
 What a container backend buys you:
 
-- The agent **cannot read `~/.hermes/.env`** (keys stay on the host)
-- The agent **cannot modify its own code**
-- Destructive commands are contained to the container filesystem
+- The agent's terminal/file operations cannot read the host `~/.hermes/.env` unless you explicitly forward env or mount credential files.
+- Destructive commands are contained to the container/sandbox filesystem.
+- Docker containers run with hardened defaults: Linux capabilities dropped except the minimum needed for package/user setup, `no-new-privileges`, PID limits, and size-limited tmpfs mounts.
 
-SSH and serverless (Modal/Daytona) backends give the same shape — agent code and keys stay local/host-side, only commands are forwarded:
+SSH and serverless (Modal/Daytona) backends give the same shape — agent code and keys stay local/host-side, only commands are forwarded. Current docs put SSH connection details in `.env` rather than `config.yaml` so they do not travel with profile exports:
 
 ```yaml
+# ~/.hermes/config.yaml
 terminal:
   backend: ssh
-  ssh_host: my-server.example.com
-  ssh_user: agent
-  ssh_port: 22
-  ssh_key: ~/.ssh/id_rsa
 ```
 
-For **true egress allowlisting** (block private ranges, block the metadata IP `169.254.169.254`, restrict outbound domains), wrap the *whole process* with [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell), which enforces hot-reloadable L7 network policy across every code path — including MCP subprocesses and the code-execution child that a terminal-only backend leaves exposed. For a home-lab / [Home Assistant](./part15-new-platforms.md#home-assistant) setup, an explicit OpenShell egress allowlist beats hoping a config key blocks SSRF (it doesn't exist).
+```bash
+# ~/.hermes/.env
+TERMINAL_SSH_HOST=agent-worker.local
+TERMINAL_SSH_USER=hermes
+TERMINAL_SSH_KEY=~/.ssh/hermes_agent_key
+```
+
+For **true egress allowlisting** (block private ranges, block the metadata IP `169.254.169.254`, restrict outbound domains across every code path), wrap the _whole process_ with a VM/container policy or [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell). Terminal-only backends do not confine in-process plugins, skills, MCP management code, or gateway/media fetches. For a home-lab / [Home Assistant](./part15-new-platforms.md#home-assistant) setup, an explicit outer egress policy beats hoping a nonexistent Hermes config key blocks every SSRF path.
+
+### URL-fetching guardrails: website blocklist and SSRF protection
+
+Hermes now has built-in URL policy for web/browser/vision/media fetches:
+
+```yaml
+security:
+  website_blocklist:
+    enabled: true
+    domains:
+      - "*.internal.company.com"
+      - "admin.example.com"
+    shared_files:
+      - "/etc/hermes/blocked-sites.txt"
+
+  allow_private_urls: false # default; leave false for public-facing gateways
+```
+
+With the default `allow_private_urls: false`, URL-capable tools reject private, loopback, link-local, CGNAT/Tailscale, reserved/multicast, and cloud-metadata targets; redirects are revalidated. Set it to `true` only for trusted local-network workflows where prompt-injected URLs probing your LAN are an acceptable risk. These URL guards are valuable, but they are not a replacement for OS/network isolation because they only cover Hermes URL-fetching paths, not arbitrary code running in a shell/container/plugin.
 
 ---
 
 ## Layer 5: MCP and Plugin Trust
 
-MCP servers and plugins are third-party code you give tool access to. Hermes does **not** have per-server `trust:` levels, `allow_sampling`, or `max_concurrent_calls` config knobs. The real controls are credential filtering, tool filtering, and **operator review before install**.
+MCP servers and plugins are third-party code you give tool access to. Hermes does **not** have per-server `trust:` levels, `allow_sampling`, or `max_concurrent_calls` config knobs. The real controls are credential filtering, tool filtering, TLS/header configuration for HTTP servers, and **operator review before install**.
 
 Configure servers with the documented [MCP schema](https://hermes-agent.nousresearch.com/docs/reference/mcp-config-reference) and use `tools.include` / `tools.exclude` to expose only the tools you audited:
 
@@ -225,11 +270,11 @@ mcp_servers:
     command: npx
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_RO_TOKEN}   # read-only, scoped PAT
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_RO_TOKEN} # read-only, scoped PAT
     enabled: true
     timeout: 120
     tools:
-      include: []          # empty = all; or list exactly the tools you trust
+      include: [] # empty = all; or list exactly the tools you trust
       exclude: []
 
   scraper-mcp:
@@ -237,24 +282,48 @@ mcp_servers:
     args: ["-y", "some-web-scraper-mcp"]
     enabled: true
     tools:
-      include: [read_docs]  # lock an untrusted-content server to read-only tools you audited
+      include: [read_docs] # lock an untrusted-content server to read-only tools you audited
 ```
 
 Trust is enforced by review and isolation, not a config flag:
 
-- **Credential filtering** strips provider keys/gateway tokens from MCP subprocess environments by default (Layer 3). Pass only what a server genuinely needs, via its `env:`.
-- **Skills run arbitrary Python at import time; plugins run with full agent privileges.** "Reviewing" a skill or plugin means reading its Python and scripts, not just its `SKILL.md`. **Skills Guard** scans installable skill content for injection patterns — treat it as a review *aid*, not a boundary.
+- **Credential filtering** strips provider keys/gateway tokens from MCP stdio environments by default (Layer 3). `terminal.env_passthrough` does **not** affect MCP; pass only what a server genuinely needs via that server's `env:`.
+- **Skills run arbitrary Python at import time; plugins run with full agent privileges.** "Reviewing" a skill or plugin means reading its Python and scripts, not just its `SKILL.md`. **Skills Guard** scans installable skill content for injection patterns — treat it as a review _aid_, not a boundary.
 - Never give a server that ingests untrusted content (web scrapers, email parsers) a broad tool surface or sensitive env. Run those flows under whole-process isolation.
 
 See [Part 17](./part17-mcp-servers.md) for install patterns.
 
 ---
 
-## Layer 6: Context-File Scanning and Injection Detection
+## Layer 6: Context-File Scanning, Session Isolation, and Input Sanitization
 
-Hermes scans **project context files** for prompt-injection patterns before they enter the model's context, and (above) **Skills Guard** scans installable skills. These catch the obvious "ignore previous instructions, exfiltrate `.env`" payloads planted in a README, an issue body, or a skill.
+Hermes scans **project context files** (`AGENTS.md`, `.cursorrules`, `SOUL.md`, etc.) for prompt-injection patterns before they enter the model's context, and **Skills Guard** scans installable skills. These catch obvious "ignore previous instructions, exfiltrate `.env`" payloads planted in a README, issue body, or skill.
 
-They are heuristics, not boundaries — a determined injection phrased novelly will pass. Their value is raising the cost of drive-by attacks. The containment story remains Layer "OS isolation": run untrusted-input sessions under a sandbox so a successful injection still can't reach host secrets or persistent state.
+The current security model also includes two less-visible guardrails:
+
+- **Cross-session isolation:** sessions cannot access each other's data/state, and cron job storage paths are hardened against path traversal.
+- **Input sanitization:** working-directory parameters in terminal backends are validated against allowlists to prevent shell injection through path fields. If you need an extra local write boundary, set `HERMES_WRITE_SAFE_ROOT` to one or more allowed prefixes; `write_file`/`patch` outside those roots require approval.
+
+These are heuristics and structural checks, not containment. A determined injection phrased novelly may pass. Their value is raising the cost of drive-by attacks; the containment story remains Layer "OS isolation": run untrusted-input sessions under a sandbox so a successful injection still can't reach host secrets or persistent state.
+
+---
+
+## Supply-Chain Controls: Advisories and Lazy Installs
+
+Hermes now flags known-compromised Python package versions in the active venv at CLI startup, `hermes doctor`, and gateway startup. After you have read and remediated an advisory, acknowledge it explicitly:
+
+```bash
+hermes doctor --ack <advisory-id>
+```
+
+The ack is stored in `security.acked_advisories`. Do not delete old advisory definitions from your mental model just because the incident is old; stale packages can survive in private mirrors and caches.
+
+Optional backend dependencies are lazy-installed on first use from an in-tree allowlist. That avoids pulling every extra dependency up front, but high-security or air-gapped deployments should disable runtime installs and preinstall audited packages instead:
+
+```yaml
+security:
+  allow_lazy_installs: false
+```
 
 ---
 
@@ -274,7 +343,7 @@ Aonan Guan's writeup has the exploit chain in full. Patch, don't just read.
 
 ## Diagnostic Bundle Safety
 
-Logs under `~/.hermes/logs/` pass through the secret redactor when `security.redact_secrets` is on (the default). Before sharing *any* debug output or log bundle with someone else:
+Logs under `~/.hermes/logs/` pass through the secret redactor when `security.redact_secrets` is on (the default). Before sharing _any_ debug output or log bundle with someone else:
 
 1. Review it first — redaction is pattern-based and not exhaustive.
 2. Never share output from a session that touched production secrets over a public link.
@@ -286,12 +355,12 @@ See [Part 16](./part16-backup-debug.md) for backup and debug workflows.
 
 ## Periodic Security Hygiene
 
-Cron the audits (these skills ship in this guide's `skills/security/` hub). Remember `approvals.cron_mode: deny` means a cron job that hits a dangerous command is blocked headlessly — keep audit skills read-only so they don't trip it:
+Cron the audits. The example skills live in this repo under `skills/security/`; install them from your local checkout or copy their prompts into `hermes cron create`. Remember `approvals.cron_mode: deny` means a cron job that hits a dangerous command is blocked headlessly — keep audit skills read-only so they don't trip it:
 
 ```yaml
 # ~/.hermes/cron.yaml
 - name: weekly-mcp-audit
-  schedule: "0 9 * * 1"              # Weekly Monday
+  schedule: "0 9 * * 1" # Weekly Monday
   task: |
     /audit-mcp
     List every MCP, its env, its tools include/exclude, and last update from npm/github.
@@ -303,10 +372,10 @@ Cron the audits (these skills ship in this guide's `skills/security/` hub). Reme
 
 - name: weekly-approval-bypass-review
   schedule: "0 10 * * 1"
-  task: /audit-approval-bypass         # flags YOLO/off/cron-approve and container-bypass surfaces
+  task: /audit-approval-bypass # flags YOLO/off/cron-approve and container-bypass surfaces
 ```
 
-Install with `hermes skills install security/audit-mcp` and `security/audit-approval-bypass`.
+If these skills are not published in your configured skills hub, install them from the checkout path (or copy the `SKILL.md` contents into your own local skills directory) rather than assuming `hermes skills install security/audit-mcp` resolves globally.
 
 ---
 


### PR DESCRIPTION
## Summary
- Refreshes Part 19 against current Hermes security docs/source
- Corrects command_allowlist and tirith behavior
- Adds current guidance for website blocklist, private URL/SSRF policy, env and credential passthrough, supply-chain advisories, and lazy-install controls
- Updates the changelog

## Checks
- git diff --check
- npx -y markdown-link-check -c .github/markdown-link-check.json part19-security-playbook.md CHANGELOG.md
- python3 .github/scripts/validate_skills.py